### PR TITLE
Add voting district maps section with two districting algorithms

### DIFF
--- a/apps/visualizations/app/components/DistrictingViz.tsx
+++ b/apps/visualizations/app/components/DistrictingViz.tsx
@@ -47,8 +47,18 @@ const DistrictMap: React.FC<DistrictMapProps> = ({
       hexToRgb(DISTRICT_COLORS[i % DISTRICT_COLORS.length])
     );
 
-    // 1. Shade the background by nearest district centroid (a light Voronoi
-    //    tint) so districts read as contiguous regions.
+    // 1. Shade the background from the *actual* district assignment: each
+    //    pixel takes the district of its nearest voter. Tinting by nearest
+    //    centroid would draw straight Voronoi boundaries that can cut through
+    //    counties the county-integrity algorithm deliberately kept whole, so
+    //    the fill would disagree with the dots and the split-count metric.
+    //    Following the assignment keeps the regions consistent with both.
+    const vx = new Float32Array(map.voters.length);
+    const vy = new Float32Array(map.voters.length);
+    for (let i = 0; i < map.voters.length; i++) {
+      vx[i] = map.voters[i].x;
+      vy[i] = map.voters[i].y;
+    }
     const img = ctx.createImageData(S, S);
     const data = img.data;
     const STEP = 2;
@@ -58,14 +68,13 @@ const DistrictMap: React.FC<DistrictMapProps> = ({
         const uy = 1 - py / S;
         let best = 0;
         let bestD = Infinity;
-        for (let d = 0; d < k; d++) {
-          const c = result.centroids[d];
-          const dx = ux - c.x;
-          const dy = uy - c.y;
+        for (let i = 0; i < vx.length; i++) {
+          const dx = ux - vx[i];
+          const dy = uy - vy[i];
           const dd = dx * dx + dy * dy;
           if (dd < bestD) {
             bestD = dd;
-            best = d;
+            best = result.assignment[i];
           }
         }
         const col = colors[best];

--- a/apps/visualizations/app/components/DistrictingViz.tsx
+++ b/apps/visualizations/app/components/DistrictingViz.tsx
@@ -1,0 +1,270 @@
+// apps/visualizations/app/components/DistrictingViz.tsx
+'use client';
+
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  DISTRICT_COLORS,
+  DistrictingResult,
+  MapData,
+  districtByCentroid,
+  districtByCounty,
+  generateMapData,
+} from '../../lib/districting';
+
+const CANVAS_SIZE = 380;
+
+function hexToRgb(hex: string): { r: number; g: number; b: number } {
+  const v = parseInt(hex.slice(1), 16);
+  return { r: (v >> 16) & 255, g: (v >> 8) & 255, b: v & 255 };
+}
+
+interface DistrictMapProps {
+  title: string;
+  description: string;
+  map: MapData;
+  result: DistrictingResult;
+  showCounties: boolean;
+}
+
+const DistrictMap: React.FC<DistrictMapProps> = ({
+  title,
+  description,
+  map,
+  result,
+  showCounties,
+}) => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const S = CANVAS_SIZE;
+    const k = result.numDistricts;
+    const colors = result.centroids.map((_, i) =>
+      hexToRgb(DISTRICT_COLORS[i % DISTRICT_COLORS.length])
+    );
+
+    // 1. Shade the background by nearest district centroid (a light Voronoi
+    //    tint) so districts read as contiguous regions.
+    const img = ctx.createImageData(S, S);
+    const data = img.data;
+    const STEP = 2;
+    for (let py = 0; py < S; py += STEP) {
+      for (let px = 0; px < S; px += STEP) {
+        const ux = px / S;
+        const uy = 1 - py / S;
+        let best = 0;
+        let bestD = Infinity;
+        for (let d = 0; d < k; d++) {
+          const c = result.centroids[d];
+          const dx = ux - c.x;
+          const dy = uy - c.y;
+          const dd = dx * dx + dy * dy;
+          if (dd < bestD) {
+            bestD = dd;
+            best = d;
+          }
+        }
+        const col = colors[best];
+        // blend toward white for a soft fill
+        const r = Math.round(col.r * 0.18 + 255 * 0.82);
+        const g = Math.round(col.g * 0.18 + 255 * 0.82);
+        const b = Math.round(col.b * 0.18 + 255 * 0.82);
+        for (let dy = 0; dy < STEP && py + dy < S; dy++) {
+          for (let dx = 0; dx < STEP && px + dx < S; dx++) {
+            const idx = ((py + dy) * S + (px + dx)) * 4;
+            data[idx] = r;
+            data[idx + 1] = g;
+            data[idx + 2] = b;
+            data[idx + 3] = 255;
+          }
+        }
+      }
+    }
+    ctx.putImageData(img, 0, 0);
+
+    // 2. County boundaries (dashed gray grid).
+    if (showCounties) {
+      ctx.strokeStyle = 'rgba(71, 85, 105, 0.55)';
+      ctx.lineWidth = 1;
+      ctx.setLineDash([4, 3]);
+      for (let c = 1; c < map.cols; c++) {
+        const x = (c / map.cols) * S;
+        ctx.beginPath();
+        ctx.moveTo(x, 0);
+        ctx.lineTo(x, S);
+        ctx.stroke();
+      }
+      for (let r = 1; r < map.rows; r++) {
+        const y = (r / map.rows) * S;
+        ctx.beginPath();
+        ctx.moveTo(0, y);
+        ctx.lineTo(S, y);
+        ctx.stroke();
+      }
+      ctx.setLineDash([]);
+    }
+
+    // 3. Voters, colored by their actual district assignment.
+    for (let i = 0; i < map.voters.length; i++) {
+      const v = map.voters[i];
+      const col = DISTRICT_COLORS[result.assignment[i] % DISTRICT_COLORS.length];
+      ctx.fillStyle = col;
+      ctx.beginPath();
+      ctx.arc(v.x * S, (1 - v.y) * S, 1.6, 0, 2 * Math.PI);
+      ctx.fill();
+    }
+
+    // 4. District centroids.
+    for (let d = 0; d < k; d++) {
+      const c = result.centroids[d];
+      const cx = c.x * S;
+      const cy = (1 - c.y) * S;
+      ctx.beginPath();
+      ctx.arc(cx, cy, 7, 0, 2 * Math.PI);
+      ctx.fillStyle = '#ffffff';
+      ctx.fill();
+      ctx.lineWidth = 3;
+      ctx.strokeStyle = DISTRICT_COLORS[d % DISTRICT_COLORS.length];
+      ctx.stroke();
+    }
+  }, [map, result, showCounties]);
+
+  const minPop = Math.min(...result.populations);
+  const maxPop = Math.max(...result.populations);
+  const imbalance = (((maxPop - minPop) / Math.max(1, maxPop)) * 100).toFixed(1);
+
+  return (
+    <div className="flex flex-col items-center">
+      <h3 className="text-lg font-semibold mb-1">{title}</h3>
+      <p className="text-sm text-gray-600 mb-3 text-center max-w-sm min-h-[2.5rem]">
+        {description}
+      </p>
+      <canvas
+        ref={canvasRef}
+        width={CANVAS_SIZE}
+        height={CANVAS_SIZE}
+        className="border border-gray-300 rounded"
+      />
+      <div className="mt-3 w-full max-w-sm text-sm space-y-1">
+        <div className="flex justify-between">
+          <span className="text-gray-600">Avg. distance to centroid</span>
+          <span className="font-mono font-medium">
+            {result.avgDistance.toFixed(4)}
+          </span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-gray-600">Population imbalance</span>
+          <span className="font-mono font-medium">
+            {imbalance}% ({minPop}–{maxPop})
+          </span>
+        </div>
+        <div className="flex justify-between">
+          <span className="text-gray-600">Counties split</span>
+          <span className="font-mono font-medium">
+            {result.splitCounties} (
+            {(result.countySplitFraction * 100).toFixed(0)}%)
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const DistrictingViz: React.FC = () => {
+  const [numDistricts, setNumDistricts] = useState(4);
+  const [seed, setSeed] = useState(1);
+
+  // counties fixed at a 4x4 grid for clarity
+  const map = useMemo(
+    () =>
+      generateMapData({
+        numVoters: 2000,
+        cols: 4,
+        rows: 4,
+        numClusters: 5,
+        seed,
+      }),
+    [seed]
+  );
+
+  const centroidResult = useMemo(
+    () => districtByCentroid(map, { numDistricts, seed }),
+    [map, numDistricts, seed]
+  );
+  const countyResult = useMemo(
+    () => districtByCounty(map, { numDistricts, seed }),
+    [map, numDistricts, seed]
+  );
+
+  return (
+    <div className="max-w-5xl mx-auto p-6">
+      <h1 className="text-3xl font-bold mb-2">Voting District Maps</h1>
+      <p className="text-gray-700 mb-6 max-w-3xl">
+        Gerrymandering works by drawing district lines to favor one group. One
+        antidote is to draw districts with a neutral, transparent rule instead.
+        Both maps below split the same population into equal-population
+        districts that are as compact as possible — the difference is whether
+        they respect existing county lines. Each dot is a voter, colored by the
+        district they end up in; the ringed markers are the district centroids,
+        and the dashed grid shows county boundaries.
+      </p>
+
+      <div className="flex flex-wrap items-end gap-6 mb-8 p-4 bg-gray-50 rounded-lg border border-gray-200">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">
+            Number of districts: {numDistricts}
+          </label>
+          <input
+            type="range"
+            min={2}
+            max={7}
+            value={numDistricts}
+            onChange={(e) => setNumDistricts(Number(e.target.value))}
+            className="w-48"
+          />
+        </div>
+        <button
+          onClick={() => setSeed((s) => s + 1)}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+        >
+          New population
+        </button>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-10">
+        <DistrictMap
+          title="1. Compactness only"
+          description="Minimizes the average distance from each voter to their district's centroid. Compact and equal-population, but it cuts across county lines freely."
+          map={map}
+          result={centroidResult}
+          showCounties
+        />
+        <DistrictMap
+          title="2. Compactness + county integrity"
+          description="Same compactness goal, but keeps whole counties together wherever reasonable. Counties are only split when needed to balance population."
+          map={map}
+          result={countyResult}
+          showCounties
+        />
+      </div>
+
+      <div className="mt-10 p-4 bg-blue-50 border border-blue-200 rounded-lg text-sm text-gray-700 max-w-3xl">
+        <p className="font-semibold mb-1">Reading the results</p>
+        <p>
+          Algorithm&nbsp;1 will usually post a slightly lower average
+          distance-to-centroid (it has more freedom), while Algorithm&nbsp;2
+          splits far fewer counties. The trade-off between raw compactness and
+          respecting communities of interest is exactly the kind of explicit,
+          measurable rule that independent redistricting commissions use in
+          place of partisan map-drawing.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default DistrictingViz;

--- a/apps/visualizations/app/districts/page.tsx
+++ b/apps/visualizations/app/districts/page.tsx
@@ -1,0 +1,9 @@
+import DistrictingViz from '../components/DistrictingViz';
+
+export default function DistrictsPage() {
+  return (
+    <main className="container mx-auto p-4">
+      <DistrictingViz />
+    </main>
+  );
+}

--- a/apps/visualizations/app/layout.tsx
+++ b/apps/visualizations/app/layout.tsx
@@ -29,8 +29,11 @@ function Navigation() {
         <Link href="/comparison" className="mr-4 hover:underline">
           Method Comparison
         </Link>
-        <Link href="/detailed" className="hover:underline">
+        <Link href="/detailed" className="mr-4 hover:underline">
           Detailed Analysis
+        </Link>
+        <Link href="/districts" className="hover:underline">
+          District Maps
         </Link>
       </div>
     </nav>

--- a/apps/visualizations/app/page.tsx
+++ b/apps/visualizations/app/page.tsx
@@ -19,6 +19,9 @@ export default function Home() {
         <Link href="/detailed" className="text-blue-600 hover:underline font-medium">
           Detailed View
         </Link>
+        <Link href="/districts" className="text-blue-600 hover:underline font-medium">
+          District Maps
+        </Link>
       </nav>
       <ElectionViz />
     </main>

--- a/apps/visualizations/lib/districting.ts
+++ b/apps/visualizations/lib/districting.ts
@@ -283,6 +283,22 @@ function meanPoint(points: Pt[]): Pt {
   return { x: sx / points.length, y: sy / points.length };
 }
 
+/**
+ * Split `n` voters into `k` integer district quotas that sum to `n` and are
+ * each within one voter of the ideal size `n / k`. Districts are given either
+ * `floor(n / k)` or `ceil(n / k)` so the spread is at most a single voter —
+ * well inside any realistic population tolerance. This is the equal-population
+ * target every assignment pass is held to, replacing the previous upper-cap-
+ * only constraint that let some districts fall far below the ideal.
+ */
+function equalPopulationQuotas(n: number, k: number): number[] {
+  const base = Math.floor(n / k);
+  const remainder = n - base * k;
+  const quotas = new Array(k).fill(base);
+  for (let d = 0; d < remainder; d++) quotas[d] += 1;
+  return quotas;
+}
+
 export interface DistrictingOptions {
   numDistricts?: number;
   seed?: number;
@@ -298,8 +314,9 @@ export interface DistrictingOptions {
  * Partition voters into `numDistricts` equal-population districts while
  * minimizing the average voter-to-centroid distance. Population balance is
  * enforced with a capacitated assignment: voters are processed in order of how
- * strongly they prefer their nearest district, and each district is capped so
- * the populations stay within `tolerance` of the ideal size.
+ * strongly they prefer their nearest district, and each district is held to an
+ * exact equal-population quota (every district lands within one voter of the
+ * ideal size, well inside `tolerance`).
  */
 export function districtByCentroid(
   map: MapData,
@@ -309,13 +326,12 @@ export function districtByCentroid(
     numDistricts: k = 4,
     seed = 1,
     maxIterations = 40,
-    tolerance = 0.02,
   } = options;
 
   const rand = mulberry32(seed * 2654435761);
   const n = map.voters.length;
   const points: Pt[] = map.voters;
-  const capacity = Math.ceil((n / k) * (1 + tolerance));
+  const quotas = equalPopulationQuotas(n, k);
 
   let centroids = kmeansPlusPlusInit(
     points,
@@ -327,7 +343,7 @@ export function districtByCentroid(
   let assignment = new Array(n).fill(-1);
 
   for (let iter = 0; iter < maxIterations; iter++) {
-    const next = balancedAssign(points, centroids, k, capacity);
+    const next = balancedAssign(points, centroids, k, quotas);
 
     // recompute centroids
     const buckets: Pt[][] = Array.from({ length: k }, () => []);
@@ -354,13 +370,18 @@ export function districtByCentroid(
  * Capacitated nearest-centroid assignment. Voters are sorted by "regret" (the
  * gap between their nearest and second-nearest district) so that voters with a
  * strong preference are placed first; each voter then takes the closest
- * district that still has room.
+ * district that still has remaining quota.
+ *
+ * Each district is capped at its exact equal-population quota, and the quotas
+ * sum to the voter count, so every district fills to exactly its quota. That
+ * enforces both an upper *and* a lower bound on population: no district can
+ * absorb leftover voters past its share, and none can be starved below it.
  */
 function balancedAssign(
   points: Pt[],
   centroids: Pt[],
   k: number,
-  capacity: number
+  quotas: number[]
 ): number[] {
   const n = points.length;
 
@@ -382,7 +403,7 @@ function balancedAssign(
   for (const entry of order) {
     let placed = false;
     for (const d of entry.order) {
-      if (counts[d] < capacity) {
+      if (counts[d] < quotas[d]) {
         assignment[entry.i] = d;
         counts[d]++;
         placed = true;
@@ -390,14 +411,68 @@ function balancedAssign(
       }
     }
     if (!placed) {
-      // every preferred district is full: fall back to the emptiest one
-      let minIdx = 0;
-      for (let d = 1; d < k; d++) if (counts[d] < counts[minIdx]) minIdx = d;
-      assignment[entry.i] = minIdx;
-      counts[minIdx]++;
+      // every preferred district is at quota: fall back to the district with
+      // the most remaining room (only reachable through floating-point ties).
+      let bestIdx = 0;
+      let bestRoom = -Infinity;
+      for (let d = 0; d < k; d++) {
+        const room = quotas[d] - counts[d];
+        if (room > bestRoom) {
+          bestRoom = room;
+          bestIdx = d;
+        }
+      }
+      assignment[entry.i] = bestIdx;
+      counts[bestIdx]++;
     }
   }
   return assignment;
+}
+
+/**
+ * Move voters from over-target districts into any district below `floor`,
+ * mutating `assignment` and `counts` in place. For each under-floor district we
+ * repeatedly steal the single voter that is cheapest to move — the one closest
+ * to the under-floor district's centroid among all voters currently sitting in
+ * a district that is still above the ideal size — until the floor is reached.
+ * This is what gives the county path a genuine lower population bound instead
+ * of only an upper cap.
+ */
+function rebalanceToFloor(
+  voters: Pt[],
+  centroids: Pt[],
+  assignment: number[],
+  counts: number[],
+  k: number,
+  floor: number
+): void {
+  const n = voters.length;
+  const ideal = n / k;
+
+  for (let d = 0; d < k; d++) {
+    while (counts[d] < floor) {
+      // candidate donors: districts currently above the ideal size
+      let bestVoter = -1;
+      let bestCost = Infinity;
+      for (let i = 0; i < n; i++) {
+        const from = assignment[i];
+        if (from === d) continue;
+        if (counts[from] <= ideal) continue; // don't starve a donor below ideal
+        const c = centroids[d];
+        const dx = voters[i].x - c.x;
+        const dy = voters[i].y - c.y;
+        const cost = dx * dx + dy * dy;
+        if (cost < bestCost) {
+          bestCost = cost;
+          bestVoter = i;
+        }
+      }
+      if (bestVoter < 0) break; // no donor above ideal; nothing left to take
+      counts[assignment[bestVoter]]--;
+      assignment[bestVoter] = d;
+      counts[d]++;
+    }
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -409,7 +484,10 @@ function balancedAssign(
  * intact wherever reasonable. Whole counties are assigned to districts first;
  * a county is only split when assigning it whole would push a district beyond
  * its population tolerance, in which case just enough of its (nearest) voters
- * are moved to balance.
+ * are moved to balance. After the greedy pass a rebalancing step moves the
+ * cheapest voters from over-quota districts into any district still below its
+ * equal-population quota, so every district lands within the tolerance band
+ * (not just under the upper cap).
  */
 export function districtByCounty(
   map: MapData,
@@ -425,6 +503,10 @@ export function districtByCounty(
   const rand = mulberry32(seed * 40503 + 7);
   const n = map.voters.length;
   const capacity = Math.ceil((n / k) * (1 + tolerance));
+  // Lower bound a district may not fall below. Splitting counties is costly, so
+  // the county path keeps a wider tolerance band than the compactness path; the
+  // floor still guarantees no district is starved well below the ideal size.
+  const floor = Math.floor((n / k) * (1 - tolerance));
 
   // group voters by county
   const countyVoters = new Map<number, number[]>();
@@ -516,6 +598,13 @@ export function districtByCounty(
         }
       }
     }
+
+    // Rebalance: any district left below its floor pulls in the voters that
+    // are cheapest to move (closest to the under-floor centroid) out of
+    // districts that are above the ideal size. This splits as few additional
+    // counties as the population balance requires while guaranteeing every
+    // district reaches the lower bound.
+    rebalanceToFloor(map.voters, centroids, next, counts, k, floor);
 
     // recompute centroids
     const buckets: Pt[][] = Array.from({ length: k }, () => []);

--- a/apps/visualizations/lib/districting.ts
+++ b/apps/visualizations/lib/districting.ts
@@ -1,0 +1,554 @@
+// apps/visualizations/lib/districting.ts
+//
+// Algorithms for drawing voting districts from a population of voters.
+//
+// The goal of this module is to illustrate *neutral*, rules-based districting
+// as a counterpoint to gerrymandering. Two algorithms are provided:
+//
+//   1. districtByCentroid  - partition voters into equal-population districts
+//                            that minimize the average distance between each
+//                            voter and their district's centroid (a balanced /
+//                            capacitated k-means). This produces compact
+//                            districts but ignores existing political
+//                            boundaries.
+//
+//   2. districtByCounty    - the same compactness objective, but counties are
+//                            kept whole wherever it is reasonable to do so.
+//                            Counties are only split when population balance
+//                            cannot otherwise be achieved.
+//
+// Everything is deterministic given a seed so the maps are stable between
+// renders.
+
+export interface Pt {
+  x: number;
+  y: number;
+}
+
+export interface DistrictVoter {
+  x: number; // 0..1
+  y: number; // 0..1
+  county: number; // index into MapData.counties
+}
+
+export interface CountyRegion {
+  id: number;
+  col: number;
+  row: number;
+  // bounding box in unit-square coordinates, used for drawing boundaries
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+export interface MapData {
+  voters: DistrictVoter[];
+  counties: CountyRegion[];
+  cols: number;
+  rows: number;
+}
+
+export interface DistrictingResult {
+  assignment: number[]; // district index for each voter
+  centroids: Pt[];
+  numDistricts: number;
+  avgDistance: number; // mean distance from a voter to its district centroid
+  populations: number[]; // voter count per district
+  splitCounties: number; // counties whose voters span more than one district
+  countySplitFraction: number; // splitCounties / number of populated counties
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic randomness
+// ---------------------------------------------------------------------------
+
+function mulberry32(seed: number): () => number {
+  let a = seed >>> 0;
+  return function () {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function gaussian(rand: () => number): number {
+  // Box-Muller transform
+  let u = 0;
+  let v = 0;
+  while (u === 0) u = rand();
+  while (v === 0) v = rand();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+
+function clamp01(x: number): number {
+  return Math.max(0, Math.min(0.999999, x));
+}
+
+function dist(a: Pt, b: Pt): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  return Math.sqrt(dx * dx + dy * dy);
+}
+
+// ---------------------------------------------------------------------------
+// Population / county generation
+// ---------------------------------------------------------------------------
+
+export interface GenerateOptions {
+  numVoters?: number;
+  cols?: number; // number of county columns
+  rows?: number; // number of county rows
+  numClusters?: number; // population centers ("cities")
+  seed?: number;
+}
+
+/**
+ * Build a synthetic state: a grid of rectangular counties overlaid on a
+ * population that is concentrated in a handful of "cities" plus a uniform
+ * rural background. Uneven population is what makes districting interesting.
+ */
+export function generateMapData(opts: GenerateOptions = {}): MapData {
+  const {
+    numVoters = 2000,
+    cols = 4,
+    rows = 4,
+    numClusters = 5,
+    seed = 1,
+  } = opts;
+
+  const rand = mulberry32(seed);
+
+  const counties: CountyRegion[] = [];
+  for (let r = 0; r < rows; r++) {
+    for (let c = 0; c < cols; c++) {
+      counties.push({
+        id: r * cols + c,
+        col: c,
+        row: r,
+        x0: c / cols,
+        y0: r / rows,
+        x1: (c + 1) / cols,
+        y1: (r + 1) / rows,
+      });
+    }
+  }
+
+  // City centers with varying weight, so some areas are dense and some sparse.
+  const clusters: { x: number; y: number; weight: number; spread: number }[] =
+    [];
+  for (let i = 0; i < numClusters; i++) {
+    clusters.push({
+      x: 0.1 + rand() * 0.8,
+      y: 0.1 + rand() * 0.8,
+      weight: 0.4 + rand() * 1.6,
+      spread: 0.04 + rand() * 0.08,
+    });
+  }
+  const totalWeight = clusters.reduce((s, c) => s + c.weight, 0);
+
+  const voters: DistrictVoter[] = [];
+  const backgroundFraction = 0.25; // share of voters spread uniformly
+
+  for (let i = 0; i < numVoters; i++) {
+    let x: number;
+    let y: number;
+    if (rand() < backgroundFraction) {
+      x = clamp01(rand());
+      y = clamp01(rand());
+    } else {
+      // pick a city weighted by population
+      let pick = rand() * totalWeight;
+      let cluster = clusters[0];
+      for (const c of clusters) {
+        pick -= c.weight;
+        if (pick <= 0) {
+          cluster = c;
+          break;
+        }
+      }
+      x = clamp01(cluster.x + gaussian(rand) * cluster.spread);
+      y = clamp01(cluster.y + gaussian(rand) * cluster.spread);
+    }
+    const col = Math.min(cols - 1, Math.floor(x * cols));
+    const row = Math.min(rows - 1, Math.floor(y * rows));
+    voters.push({ x, y, county: row * cols + col });
+  }
+
+  return { voters, counties, cols, rows };
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function kmeansPlusPlusInit(
+  points: Pt[],
+  weights: number[],
+  k: number,
+  rand: () => number
+): Pt[] {
+  const centroids: Pt[] = [];
+  const totalWeight = weights.reduce((s, w) => s + w, 0);
+
+  // first centroid: weighted random
+  let pick = rand() * totalWeight;
+  let firstIdx = 0;
+  for (let i = 0; i < points.length; i++) {
+    pick -= weights[i];
+    if (pick <= 0) {
+      firstIdx = i;
+      break;
+    }
+  }
+  centroids.push({ ...points[firstIdx] });
+
+  while (centroids.length < k) {
+    // distance^2 to nearest existing centroid, weighted
+    const d2: number[] = points.map((p, i) => {
+      let best = Infinity;
+      for (const c of centroids) {
+        const dd = dist(p, c);
+        if (dd * dd < best) best = dd * dd;
+      }
+      return best * weights[i];
+    });
+    const sum = d2.reduce((s, v) => s + v, 0);
+    if (sum <= 0) {
+      // all remaining points coincide with centroids; just duplicate one
+      centroids.push({ ...points[Math.floor(rand() * points.length)] });
+      continue;
+    }
+    let r = rand() * sum;
+    let chosen = 0;
+    for (let i = 0; i < points.length; i++) {
+      r -= d2[i];
+      if (r <= 0) {
+        chosen = i;
+        break;
+      }
+    }
+    centroids.push({ ...points[chosen] });
+  }
+  return centroids;
+}
+
+function computeStats(
+  map: MapData,
+  assignment: number[],
+  centroids: Pt[],
+  k: number
+): Omit<DistrictingResult, 'assignment' | 'centroids' | 'numDistricts'> {
+  const populations = new Array(k).fill(0);
+  let totalDist = 0;
+  for (let i = 0; i < map.voters.length; i++) {
+    const d = assignment[i];
+    populations[d]++;
+    totalDist += dist(map.voters[i], centroids[d]);
+  }
+  const avgDistance = totalDist / Math.max(1, map.voters.length);
+
+  // count counties whose voters land in more than one district
+  const countyDistricts = new Map<number, Set<number>>();
+  const populatedCounties = new Set<number>();
+  for (let i = 0; i < map.voters.length; i++) {
+    const cty = map.voters[i].county;
+    populatedCounties.add(cty);
+    if (!countyDistricts.has(cty)) countyDistricts.set(cty, new Set());
+    countyDistricts.get(cty)!.add(assignment[i]);
+  }
+  let splitCounties = 0;
+  countyDistricts.forEach((set) => {
+    if (set.size > 1) splitCounties++;
+  });
+
+  return {
+    avgDistance,
+    populations,
+    splitCounties,
+    countySplitFraction: splitCounties / Math.max(1, populatedCounties.size),
+  };
+}
+
+function meanPoint(points: Pt[]): Pt {
+  if (points.length === 0) return { x: 0.5, y: 0.5 };
+  let sx = 0;
+  let sy = 0;
+  for (const p of points) {
+    sx += p.x;
+    sy += p.y;
+  }
+  return { x: sx / points.length, y: sy / points.length };
+}
+
+export interface DistrictingOptions {
+  numDistricts?: number;
+  seed?: number;
+  maxIterations?: number;
+  tolerance?: number; // allowed overshoot of ideal district size (0.05 = 5%)
+}
+
+// ---------------------------------------------------------------------------
+// Algorithm 1: balanced centroid k-means
+// ---------------------------------------------------------------------------
+
+/**
+ * Partition voters into `numDistricts` equal-population districts while
+ * minimizing the average voter-to-centroid distance. Population balance is
+ * enforced with a capacitated assignment: voters are processed in order of how
+ * strongly they prefer their nearest district, and each district is capped so
+ * the populations stay within `tolerance` of the ideal size.
+ */
+export function districtByCentroid(
+  map: MapData,
+  options: DistrictingOptions = {}
+): DistrictingResult {
+  const {
+    numDistricts: k = 4,
+    seed = 1,
+    maxIterations = 40,
+    tolerance = 0.02,
+  } = options;
+
+  const rand = mulberry32(seed * 2654435761);
+  const n = map.voters.length;
+  const points: Pt[] = map.voters;
+  const capacity = Math.ceil((n / k) * (1 + tolerance));
+
+  let centroids = kmeansPlusPlusInit(
+    points,
+    new Array(n).fill(1),
+    k,
+    rand
+  );
+
+  let assignment = new Array(n).fill(-1);
+
+  for (let iter = 0; iter < maxIterations; iter++) {
+    const next = balancedAssign(points, centroids, k, capacity);
+
+    // recompute centroids
+    const buckets: Pt[][] = Array.from({ length: k }, () => []);
+    for (let i = 0; i < n; i++) buckets[next[i]].push(points[i]);
+    const newCentroids = buckets.map((b, idx) =>
+      b.length ? meanPoint(b) : centroids[idx]
+    );
+
+    const changed = next.some((d, i) => d !== assignment[i]);
+    assignment = next;
+    centroids = newCentroids;
+    if (!changed) break;
+  }
+
+  return {
+    assignment,
+    centroids,
+    numDistricts: k,
+    ...computeStats(map, assignment, centroids, k),
+  };
+}
+
+/**
+ * Capacitated nearest-centroid assignment. Voters are sorted by "regret" (the
+ * gap between their nearest and second-nearest district) so that voters with a
+ * strong preference are placed first; each voter then takes the closest
+ * district that still has room.
+ */
+function balancedAssign(
+  points: Pt[],
+  centroids: Pt[],
+  k: number,
+  capacity: number
+): number[] {
+  const n = points.length;
+
+  const order: { i: number; regret: number; order: number[] }[] = [];
+  for (let i = 0; i < n; i++) {
+    const ds = centroids.map((c, idx) => ({ idx, d: dist(points[i], c) }));
+    ds.sort((a, b) => a.d - b.d);
+    order.push({
+      i,
+      regret: (ds[1]?.d ?? ds[0].d) - ds[0].d,
+      order: ds.map((o) => o.idx),
+    });
+  }
+  order.sort((a, b) => b.regret - a.regret);
+
+  const counts = new Array(k).fill(0);
+  const assignment = new Array(n).fill(-1);
+
+  for (const entry of order) {
+    let placed = false;
+    for (const d of entry.order) {
+      if (counts[d] < capacity) {
+        assignment[entry.i] = d;
+        counts[d]++;
+        placed = true;
+        break;
+      }
+    }
+    if (!placed) {
+      // every preferred district is full: fall back to the emptiest one
+      let minIdx = 0;
+      for (let d = 1; d < k; d++) if (counts[d] < counts[minIdx]) minIdx = d;
+      assignment[entry.i] = minIdx;
+      counts[minIdx]++;
+    }
+  }
+  return assignment;
+}
+
+// ---------------------------------------------------------------------------
+// Algorithm 2: county-preserving districting
+// ---------------------------------------------------------------------------
+
+/**
+ * Same compactness objective as `districtByCentroid`, but counties are kept
+ * intact wherever reasonable. Whole counties are assigned to districts first;
+ * a county is only split when assigning it whole would push a district beyond
+ * its population tolerance, in which case just enough of its (nearest) voters
+ * are moved to balance.
+ */
+export function districtByCounty(
+  map: MapData,
+  options: DistrictingOptions = {}
+): DistrictingResult {
+  const {
+    numDistricts: k = 4,
+    seed = 1,
+    maxIterations = 30,
+    tolerance = 0.08,
+  } = options;
+
+  const rand = mulberry32(seed * 40503 + 7);
+  const n = map.voters.length;
+  const capacity = Math.ceil((n / k) * (1 + tolerance));
+
+  // group voters by county
+  const countyVoters = new Map<number, number[]>();
+  for (let i = 0; i < n; i++) {
+    const cty = map.voters[i].county;
+    if (!countyVoters.has(cty)) countyVoters.set(cty, []);
+    countyVoters.get(cty)!.push(i);
+  }
+  const countyIds = Array.from(countyVoters.keys());
+  const countyCentroid = new Map<number, Pt>();
+  const countyPop = new Map<number, number>();
+  countyVoters.forEach((idxs, cty) => {
+    countyCentroid.set(
+      cty,
+      meanPoint(idxs.map((i) => map.voters[i]))
+    );
+    countyPop.set(cty, idxs.length);
+  });
+
+  // seed district centroids from county centroids, weighted by population
+  let centroids = kmeansPlusPlusInit(
+    countyIds.map((c) => countyCentroid.get(c)!),
+    countyIds.map((c) => countyPop.get(c)!),
+    k,
+    rand
+  );
+
+  let assignment = new Array(n).fill(-1);
+
+  for (let iter = 0; iter < maxIterations; iter++) {
+    const next = new Array(n).fill(-1);
+    const counts = new Array(k).fill(0);
+
+    // assign whole counties first, hardest-to-place (highest regret) first
+    const ranked = countyIds
+      .map((cty) => {
+        const cc = countyCentroid.get(cty)!;
+        const ds = centroids
+          .map((c, idx) => ({ idx, d: dist(cc, c) }))
+          .sort((a, b) => a.d - b.d);
+        return {
+          cty,
+          order: ds.map((o) => o.idx),
+          regret: (ds[1]?.d ?? ds[0].d) - ds[0].d,
+        };
+      })
+      .sort((a, b) => b.regret - a.regret);
+
+    for (const { cty, order } of ranked) {
+      const idxs = countyVoters.get(cty)!;
+      const pop = idxs.length;
+
+      // try to keep the county whole in its most-preferred district with room
+      let wholeDistrict = -1;
+      for (const d of order) {
+        if (counts[d] + pop <= capacity) {
+          wholeDistrict = d;
+          break;
+        }
+      }
+
+      if (wholeDistrict >= 0) {
+        for (const i of idxs) next[i] = wholeDistrict;
+        counts[wholeDistrict] += pop;
+      } else {
+        // must split: assign each voter to its nearest district that still has
+        // room (this only happens when no single district can absorb the whole
+        // county without exceeding tolerance)
+        for (const i of idxs) {
+          const ds = centroids
+            .map((c, idx) => ({ idx, d: dist(map.voters[i], c) }))
+            .sort((a, b) => a.d - b.d);
+          let placed = false;
+          for (const o of ds) {
+            if (counts[o.idx] < capacity) {
+              next[i] = o.idx;
+              counts[o.idx]++;
+              placed = true;
+              break;
+            }
+          }
+          if (!placed) {
+            let minIdx = 0;
+            for (let d = 1; d < k; d++)
+              if (counts[d] < counts[minIdx]) minIdx = d;
+            next[i] = minIdx;
+            counts[minIdx]++;
+          }
+        }
+      }
+    }
+
+    // recompute centroids
+    const buckets: Pt[][] = Array.from({ length: k }, () => []);
+    for (let i = 0; i < n; i++) buckets[next[i]].push(map.voters[i]);
+    const newCentroids = buckets.map((b, idx) =>
+      b.length ? meanPoint(b) : centroids[idx]
+    );
+
+    const changed = next.some((d, i) => d !== assignment[i]);
+    assignment = next;
+    centroids = newCentroids;
+    if (!changed) break;
+  }
+
+  return {
+    assignment,
+    centroids,
+    numDistricts: k,
+    ...computeStats(map, assignment, centroids, k),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// District colors
+// ---------------------------------------------------------------------------
+
+export const DISTRICT_COLORS = [
+  '#2563eb', // blue
+  '#dc2626', // red
+  '#16a34a', // green
+  '#d97706', // amber
+  '#7c3aed', // violet
+  '#db2777', // pink
+  '#0891b2', // cyan
+  '#65a30d', // lime
+];


### PR DESCRIPTION
Adds a new 'District Maps' section to the visualizations app for
anti-gerrymandering work. It draws the same population into
equal-population districts using two neutral, rules-based algorithms
and compares them side by side:

1. Compactness only - balanced (capacitated) k-means that minimizes the
   average distance between voters and their district centroid.
2. Compactness + county integrity - same objective, but keeps whole
   counties together wherever reasonable, only splitting a county when
   needed to balance population.

Each map reports average distance-to-centroid, population imbalance, and
the number of counties split, making the compactness vs. community
trade-off explicit.