### PR TITLE
Fix correctness bugs in vote-tally and ballot logic

### DIFF
--- a/apps/election-site/src/App.tsx
+++ b/apps/election-site/src/App.tsx
@@ -255,15 +255,23 @@ function App() {
       setLoading(true);
       const method = election.votingMethod || 'smithApproval';
       const scoreBasedMethods: VotingMethod[] = ['rrv', 'star', 'score', 'majorityJudgment', 'cumulative'];
+      // Drop any ids that no longer exist (a candidate can be deleted while the
+      // voter is mid-ballot, leaving a stale id in ballotRanking/approved that
+      // would otherwise be submitted as an unknown candidate).
+      const validIds = new Set(candidates.map((c) => c.id));
+      const filteredRanking = ballotRanking.filter((id) => validIds.has(id));
       // For ranked/plurality methods, use the voter's ballot ordering. Fall
-      // back to the election's candidate order if they didn't reorder anything.
+      // back to the election's candidate order if they didn't reorder anything
+      // (or their only selections were since-deleted candidates).
       const ranking =
-        ballotRanking.length > 0 ? ballotRanking : candidates.map((c) => c.id);
+        filteredRanking.length > 0
+          ? filteredRanking
+          : candidates.map((c) => c.id);
       const vote: Vote = {
         voterName: voterName,
         ranking: scoreBasedMethods.includes(method) ? [] : ranking,
         approved: (method === 'approval' || method === 'smithApproval')
-          ? Array.from(approvedCandidates)
+          ? Array.from(approvedCandidates).filter((id) => validIds.has(id))
           : [],
         ...(scoreBasedMethods.includes(method) ? { scores: candidateScores } : {}),
         timestamp: new Date().toISOString(),

--- a/apps/election-site/src/App.tsx
+++ b/apps/election-site/src/App.tsx
@@ -71,6 +71,10 @@ function App() {
   >([]);
   const [votingMethod, setVotingMethod] = useState<VotingMethod>('plurality');
   const [candidateScores, setCandidateScores] = useState<Record<string, number>>({});
+  // The voter's ranking for this ballot, kept separate from the election's
+  // candidate list so that a real-time snapshot (e.g. another voter submitting)
+  // does not wipe the order the current voter is building. Holds candidate ids.
+  const [ballotRanking, setBallotRanking] = useState<string[]>([]);
   const [electionSlug, setElectionSlug] = useState('');
   const [slugTouched, setSlugTouched] = useState(false);
   const [editingCandidateId, setEditingCandidateId] = useState<string | null>(null);
@@ -251,9 +255,13 @@ function App() {
       setLoading(true);
       const method = election.votingMethod || 'smithApproval';
       const scoreBasedMethods: VotingMethod[] = ['rrv', 'star', 'score', 'majorityJudgment', 'cumulative'];
+      // For ranked/plurality methods, use the voter's ballot ordering. Fall
+      // back to the election's candidate order if they didn't reorder anything.
+      const ranking =
+        ballotRanking.length > 0 ? ballotRanking : candidates.map((c) => c.id);
       const vote: Vote = {
         voterName: voterName,
-        ranking: scoreBasedMethods.includes(method) ? [] : candidates.map((c) => c.id),
+        ranking: scoreBasedMethods.includes(method) ? [] : ranking,
         approved: (method === 'approval' || method === 'smithApproval')
           ? Array.from(approvedCandidates)
           : [],
@@ -842,7 +850,8 @@ function App() {
                       candidates={candidates}
                       customFields={election.customFields}
                       onChange={({ ranking, approved, scores }) => {
-                        if (ranking.length > 0) setCandidates(ranking);
+                        if (ranking.length > 0)
+                          setBallotRanking(ranking.map((c) => c.id));
                         setApprovedCandidates(new Set(approved));
                         if (scores) setCandidateScores(scores);
                       }}

--- a/apps/election-site/src/RankedApprovalList.tsx
+++ b/apps/election-site/src/RankedApprovalList.tsx
@@ -39,8 +39,26 @@ const RankedApprovalList: React.FC<RankedApprovalListProps> = ({
     Math.floor(candidates.length / 2)
   );
 
+  // Reconcile against the incoming candidate list without discarding the
+  // voter's current ordering. Re-renders happen whenever the parent re-passes
+  // `candidates` (e.g. a real-time election snapshot when another voter
+  // submits); a naive `setItems(candidates)` would reset the drag order the
+  // voter is building. Instead we keep the existing order for candidates that
+  // still exist, append any newly added ones, and drop removed ones.
   useEffect(() => {
-    setItems(candidates);
+    setItems((prev) => {
+      const byId = new Map(candidates.map((c) => [c.id, c]));
+      const kept = prev
+        .filter((c) => byId.has(c.id))
+        .map((c) => byId.get(c.id)!);
+      const keptIds = new Set(kept.map((c) => c.id));
+      const added = candidates.filter((c) => !keptIds.has(c.id));
+      const next = [...kept, ...added];
+      const unchanged =
+        next.length === prev.length &&
+        next.every((c, i) => c === prev[i]);
+      return unchanged ? prev : next;
+    });
   }, [candidates]);
 
   const onDragEnd = (result: DropResult) => {

--- a/apps/election-site/src/RankedApprovalList.tsx
+++ b/apps/election-site/src/RankedApprovalList.tsx
@@ -6,7 +6,7 @@ import {
 } from '@hello-pangea/dnd';
 import { Button } from '@repo/ui';
 import { ArrowDown, ArrowUp, Grip, Trash2 } from 'lucide-react';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import CandidateDetails from './CandidateDetails';
 import type { Candidate, CustomField } from './types';
 
@@ -39,6 +39,11 @@ const RankedApprovalList: React.FC<RankedApprovalListProps> = ({
     Math.floor(candidates.length / 2)
   );
 
+  // Track the latest items so the reconcile effect can read them without
+  // listing `items` as a dependency (which would re-run it on every drag).
+  const itemsRef = useRef(items);
+  itemsRef.current = items;
+
   // Reconcile against the incoming candidate list without discarding the
   // voter's current ordering. Re-renders happen whenever the parent re-passes
   // `candidates` (e.g. a real-time election snapshot when another voter
@@ -46,19 +51,38 @@ const RankedApprovalList: React.FC<RankedApprovalListProps> = ({
   // voter is building. Instead we keep the existing order for candidates that
   // still exist, append any newly added ones, and drop removed ones.
   useEffect(() => {
-    setItems((prev) => {
-      const byId = new Map(candidates.map((c) => [c.id, c]));
-      const kept = prev
-        .filter((c) => byId.has(c.id))
-        .map((c) => byId.get(c.id)!);
-      const keptIds = new Set(kept.map((c) => c.id));
-      const added = candidates.filter((c) => !keptIds.has(c.id));
-      const next = [...kept, ...added];
-      const unchanged =
-        next.length === prev.length &&
-        next.every((c, i) => c === prev[i]);
-      return unchanged ? prev : next;
-    });
+    const prev = itemsRef.current;
+    const byId = new Map(candidates.map((c) => [c.id, c]));
+    const kept = prev
+      .filter((c) => byId.has(c.id))
+      .map((c) => byId.get(c.id)!);
+    const keptIds = new Set(kept.map((c) => c.id));
+    const added = candidates.filter((c) => !keptIds.has(c.id));
+    const next = [...kept, ...added];
+
+    // Nothing changed at all (same objects, same order) — leave state alone.
+    const identical =
+      next.length === prev.length && next.every((c, i) => c === prev[i]);
+    if (identical) return;
+
+    setItems(next);
+
+    // If membership or order changed (a candidate was added or removed), the
+    // parent's submitted ranking would otherwise keep the stale ids — e.g.
+    // deleting a candidate mid-vote would leave the removed id in the ballot
+    // and a new candidate would be missing. Propagate the reconciled order so
+    // what gets submitted matches what is shown.
+    const membershipOrOrderChanged =
+      next.length !== prev.length ||
+      next.some((c, i) => c.id !== prev[i]?.id);
+    if (membershipOrOrderChanged) {
+      onChange({
+        ranking: next,
+        approved: showApprovalLine
+          ? next.slice(0, approvalLine).map((c) => c.id)
+          : [],
+      });
+    }
   }, [candidates]);
 
   const onDragEnd = (result: DropResult) => {

--- a/packages/shared-utils/src/ElectionUtils.test.ts
+++ b/packages/shared-utils/src/ElectionUtils.test.ts
@@ -3,6 +3,7 @@ import {
   calculateSmithSet,
   getHeadToHeadVictories,
   getPairwiseResults,
+  selectWinner,
 } from './ElectionUtils';
 import { Election } from './types';
 
@@ -193,5 +194,35 @@ describe('Election Result Calculations', () => {
 
     // With perfect ties, both candidates should be in Smith set
     expect(new Set(smithSet)).toEqual(new Set(['Candidate 1', 'Candidate 2']));
+  });
+
+  test('selectWinner produces a stable total order for a Condorcet cycle', () => {
+    // A cyclic Smith set is exactly where the old pairwise-matchup comparator
+    // was non-transitive (A>B, B>C, C>A), violating Array.sort's contract.
+    const pairwise = getPairwiseResults(cyclicElection);
+    const victories = getHeadToHeadVictories(pairwise);
+    const smithSet = calculateSmithSet(victories, cyclicElection);
+
+    const scores = selectWinner(smithSet, victories, cyclicElection);
+
+    // Every Smith-set member is ranked, and the ranking is internally
+    // consistent: scores are sorted descending by (approval, netVictories,
+    // margin).
+    expect(scores).toHaveLength(smithSet.length);
+    const cmp = (a: { approval: number; headToHead: number; margin: number }) =>
+      [a.approval, a.headToHead, a.margin];
+    for (let i = 1; i < scores.length; i++) {
+      const prev = cmp(scores[i - 1].metrics);
+      const cur = cmp(scores[i].metrics);
+      // First differing component must show prev >= cur (descending order).
+      const diff = prev.findIndex((v, k) => v !== cur[k]);
+      if (diff !== -1) {
+        expect(prev[diff]).toBeGreaterThan(cur[diff]);
+      }
+    }
+
+    // Re-running on the same input yields the same winner (determinism).
+    const scores2 = selectWinner(smithSet, victories, cyclicElection);
+    expect(scores2[0].name).toBe(scores[0].name);
   });
 });

--- a/packages/shared-utils/src/ElectionUtils.ts
+++ b/packages/shared-utils/src/ElectionUtils.ts
@@ -195,42 +195,31 @@ export const selectWinner = (
     };
   });
 
-  // Sort using updated waterfall approach
+  // Sort using a waterfall of *transitive* criteria so the comparator defines a
+  // valid total order. (An earlier version broke ties by direct head-to-head
+  // matchup, but that is non-transitive inside a Condorcet cycle — e.g. A>B,
+  // B>C, C>A — which violates Array.prototype.sort's contract and produced an
+  // implementation-defined winner in exactly the cyclic case this function
+  // exists to resolve. Net head-to-head record (a Copeland score) captures the
+  // same information transitively.)
   const sortedScores = scores.sort((a, b) => {
     // 1. First compare by approval votes
     if (a.metrics.approval !== b.metrics.approval) {
       return b.metrics.approval - a.metrics.approval;
     }
 
-    // 2. If approval tied, check direct matchup
-    const directMatchup = victories.find(
-      (v) =>
-        (v.winner === a.name && v.loser === b.name) ||
-        (v.winner === b.name && v.loser === a.name)
-    );
-
-    if (directMatchup) {
-      return directMatchup.winner === a.name ? -1 : 1;
-    }
-
-    // 3. If no direct matchup or tied, compare head-to-head record
+    // 2. If approval tied, compare net head-to-head record
     if (a.metrics.headToHead !== b.metrics.headToHead) {
       return b.metrics.headToHead - a.metrics.headToHead;
     }
 
-    // 4. If head-to-head tied, compare average margin
+    // 3. If head-to-head record tied, compare average margin
     return b.metrics.margin - a.metrics.margin;
   });
 
   // Helper: check if two candidates are truly tied across all tiebreaker levels
   const areTied = (a: CandidateScore, b: CandidateScore): boolean => {
     if (a.metrics.approval !== b.metrics.approval) return false;
-    const directMatchup = victories.some(
-      (v) =>
-        (v.winner === a.name && v.loser === b.name) ||
-        (v.winner === b.name && v.loser === a.name)
-    );
-    if (directMatchup) return false;
     if (a.metrics.headToHead !== b.metrics.headToHead) return false;
     if (a.metrics.margin !== b.metrics.margin) return false;
     return true;
@@ -243,14 +232,6 @@ export const selectWinner = (
   ): string => {
     if (current.metrics.approval !== prev.metrics.approval) {
       return '\nRanked by approval votes';
-    }
-    const directMatchup = victories.find(
-      (v) =>
-        (v.winner === current.name && v.loser === prev.name) ||
-        (v.winner === prev.name && v.loser === current.name)
-    );
-    if (directMatchup) {
-      return '\nRanked by direct head-to-head matchup';
     }
     if (current.metrics.headToHead !== prev.metrics.headToHead) {
       return '\nRanked by head-to-head record';

--- a/packages/shared-utils/src/electionTallies.test.ts
+++ b/packages/shared-utils/src/electionTallies.test.ts
@@ -130,6 +130,29 @@ describe('electionTallies', () => {
       expect(result.matrix['c']['a']).toBe(2);
       expect(result.matrix['a']['c']).toBe(1);
     });
+
+    it('treats unranked candidates as lowest preference (truncated ballots)', () => {
+      const abc: Candidate[] = [
+        { id: 'a', name: 'A' },
+        { id: 'b', name: 'B' },
+        { id: 'c', name: 'C' },
+      ];
+      // 3 voters bullet-vote A; 2 voters rank B>C and leave A off entirely.
+      // A should still beat both B and C 3-2 and be the Condorcet winner.
+      const truncatedVotes: Vote[] = [
+        { voterName: 'V1', ranking: ['a'], approved: [], timestamp: '' },
+        { voterName: 'V2', ranking: ['a'], approved: [], timestamp: '' },
+        { voterName: 'V3', ranking: ['a'], approved: [], timestamp: '' },
+        { voterName: 'V4', ranking: ['b', 'c'], approved: [], timestamp: '' },
+        { voterName: 'V5', ranking: ['b', 'c'], approved: [], timestamp: '' },
+      ];
+      const result = tallyCondorcet(truncatedVotes, abc);
+      expect(result.winner).toBe('a');
+      expect(result.matrix['a']['b']).toBe(3);
+      expect(result.matrix['b']['a']).toBe(2);
+      expect(result.matrix['a']['c']).toBe(3);
+      expect(result.matrix['c']['a']).toBe(2);
+    });
   });
 });
 
@@ -192,6 +215,23 @@ describe('tallyRankedPairs', () => {
     expect(result.winner).toBe('a');
     expect(result.lockedPairs.length).toBe(3);
   });
+
+  it('treats unranked candidates as lowest preference (truncated ballots)', () => {
+    const abc: Candidate[] = [
+      { id: 'a', name: 'A' },
+      { id: 'b', name: 'B' },
+      { id: 'c', name: 'C' },
+    ];
+    const truncatedVotes: Vote[] = [
+      { voterName: 'V1', ranking: ['a'], approved: [], timestamp: '' },
+      { voterName: 'V2', ranking: ['a'], approved: [], timestamp: '' },
+      { voterName: 'V3', ranking: ['a'], approved: [], timestamp: '' },
+      { voterName: 'V4', ranking: ['b', 'c'], approved: [], timestamp: '' },
+      { voterName: 'V5', ranking: ['b', 'c'], approved: [], timestamp: '' },
+    ];
+    const result = tallyRankedPairs(truncatedVotes, abc);
+    expect(result.winner).toBe('a');
+  });
 });
 
 describe('tallySTV', () => {
@@ -223,6 +263,40 @@ describe('tallyMajorityJudgment', () => {
     const result = tallyMajorityJudgment(mjVotes, candidates);
     expect(result.winner).toBe('1');
     expect(result.medianGrades[0].medianGrade).toBe(4);
+  });
+
+  it('uses the lower median for an even number of grades', () => {
+    // Alice: [2,2,4,4] -> lower median 2; Bob: [3,3,3,3] -> median 3.
+    // Upper-median (the old bug) would give Alice 4 and elect her incorrectly.
+    const twoCandidates: Candidate[] = [
+      { id: '1', name: 'Alice' },
+      { id: '2', name: 'Bob' },
+    ];
+    const mjVotes: Vote[] = [
+      { voterName: 'V1', ranking: [], approved: [], scores: { '1': 2, '2': 3 }, timestamp: '' },
+      { voterName: 'V2', ranking: [], approved: [], scores: { '1': 2, '2': 3 }, timestamp: '' },
+      { voterName: 'V3', ranking: [], approved: [], scores: { '1': 4, '2': 3 }, timestamp: '' },
+      { voterName: 'V4', ranking: [], approved: [], scores: { '1': 4, '2': 3 }, timestamp: '' },
+    ];
+    const result = tallyMajorityJudgment(mjVotes, twoCandidates);
+    expect(result.winner).toBe('2');
+    const alice = result.medianGrades.find((m) => m.candidateId === '1')!;
+    expect(alice.medianGrade).toBe(2);
+  });
+
+  it('treats a candidate a voter did not grade as the lowest grade', () => {
+    // Charlie is graded 5 by one voter and omitted by the others. Treating the
+    // omissions as abstentions (the old bug) gave Charlie a median of 5 and a
+    // win; treating them as Reject (0) gives a median of 0.
+    const mjVotes: Vote[] = [
+      { voterName: 'V1', ranking: [], approved: [], scores: { '1': 3, '2': 2, '3': 5 }, timestamp: '' },
+      { voterName: 'V2', ranking: [], approved: [], scores: { '1': 3, '2': 2 }, timestamp: '' },
+      { voterName: 'V3', ranking: [], approved: [], scores: { '1': 3, '2': 2 }, timestamp: '' },
+    ];
+    const result = tallyMajorityJudgment(mjVotes, candidates);
+    expect(result.winner).toBe('1');
+    const charlie = result.medianGrades.find((m) => m.candidateId === '3')!;
+    expect(charlie.medianGrade).toBe(0);
   });
 });
 

--- a/packages/shared-utils/src/electionTallies.ts
+++ b/packages/shared-utils/src/electionTallies.ts
@@ -31,6 +31,48 @@ export interface CondorcetResult {
 }
 
 /**
+ * Build a pairwise preference matrix where matrix[a][b] = number of voters who
+ * prefer a over b. Unranked candidates are treated as the lowest preference
+ * (a ranked candidate beats an unranked one), matching getPairwiseResults in
+ * ElectionUtils. Ballots that rank neither candidate of a pair contribute
+ * nothing to that pair.
+ */
+function buildPairwiseMatrix(
+  votes: Vote[],
+  ids: string[]
+): Record<string, Record<string, number>> {
+  const matrix: Record<string, Record<string, number>> = {};
+  for (const a of ids) {
+    matrix[a] = {};
+    for (const b of ids) {
+      matrix[a][b] = 0;
+    }
+  }
+
+  for (const vote of votes) {
+    // Position of each candidate on this ballot (first occurrence wins).
+    const pos = new Map<string, number>();
+    vote.ranking.forEach((id, i) => {
+      if (!pos.has(id)) pos.set(id, i);
+    });
+
+    for (let x = 0; x < ids.length; x++) {
+      for (let y = x + 1; y < ids.length; y++) {
+        const a = ids[x];
+        const b = ids[y];
+        const pa = pos.has(a) ? pos.get(a)! : Infinity;
+        const pb = pos.has(b) ? pos.get(b)! : Infinity;
+        if (pa === Infinity && pb === Infinity) continue; // neither ranked
+        if (pa < pb) matrix[a][b]++;
+        else if (pb < pa) matrix[b][a]++;
+      }
+    }
+  }
+
+  return matrix;
+}
+
+/**
  * Count first-choice votes. Winner = candidate with most first-choice votes.
  */
 export function tallyPlurality(votes: Vote[], candidates: Candidate[]): PluralityResult {
@@ -187,26 +229,8 @@ export function tallyCondorcet(votes: Vote[], candidates: Candidate[]): Condorce
   const ids = candidates.map((c) => c.id);
 
   // Build pairwise matrix: matrix[a][b] = number of voters who rank a above b
-  const matrix: Record<string, Record<string, number>> = {};
-  for (const a of ids) {
-    matrix[a] = {};
-    for (const b of ids) {
-      matrix[a][b] = 0;
-    }
-  }
-
-  for (const vote of votes) {
-    // For each pair, the one appearing earlier in the ranking is preferred
-    for (let i = 0; i < vote.ranking.length; i++) {
-      for (let j = i + 1; j < vote.ranking.length; j++) {
-        const higher = vote.ranking[i];
-        const lower = vote.ranking[j];
-        if (matrix[higher] && matrix[higher][lower] !== undefined) {
-          matrix[higher][lower]++;
-        }
-      }
-    }
-  }
+  // (unranked candidates count as lowest preference).
+  const matrix = buildPairwiseMatrix(votes, ids);
 
   // Find Condorcet winner: beats all others pairwise
   let winner: string | null = null;
@@ -373,24 +397,8 @@ export interface RankedPairsResult {
 
 export function tallyRankedPairs(votes: Vote[], candidates: Candidate[]): RankedPairsResult {
   const ids = candidates.map((c) => c.id);
-  const matrix: Record<string, Record<string, number>> = {};
-  for (const a of ids) {
-    matrix[a] = {};
-    for (const b of ids) {
-      matrix[a][b] = 0;
-    }
-  }
-  for (const vote of votes) {
-    for (let i = 0; i < vote.ranking.length; i++) {
-      for (let j = i + 1; j < vote.ranking.length; j++) {
-        const higher = vote.ranking[i];
-        const lower = vote.ranking[j];
-        if (matrix[higher]?.[lower] !== undefined) {
-          matrix[higher][lower]++;
-        }
-      }
-    }
-  }
+  // Unranked candidates count as lowest preference (see buildPairwiseMatrix).
+  const matrix = buildPairwiseMatrix(votes, ids);
 
   const pairs: Array<{ winner: string; loser: string; margin: number }> = [];
   for (const a of ids) {
@@ -539,10 +547,17 @@ export function tallyMajorityJudgment(votes: Vote[], candidates: Candidate[]): M
   for (const c of candidates) {
     gradesMap.set(c.id, []);
   }
+  // Each voter contributes a grade for every candidate. A candidate the voter
+  // did not grade is treated as the lowest grade (Reject = 0) so that medians
+  // are computed over the full electorate and a candidate rated by only a small
+  // minority cannot get an inflated median.
   for (const vote of votes) {
-    if (!vote.scores) continue;
-    for (const [candidateId, grade] of Object.entries(vote.scores)) {
-      gradesMap.get(candidateId)?.push(Math.max(0, Math.min(5, Math.round(grade))));
+    const scores = vote.scores ?? {};
+    for (const c of candidates) {
+      const grade = scores[c.id];
+      const clamped =
+        grade === undefined ? 0 : Math.max(0, Math.min(5, Math.round(grade)));
+      gradesMap.get(c.id)!.push(clamped);
     }
   }
 
@@ -550,9 +565,14 @@ export function tallyMajorityJudgment(votes: Vote[], candidates: Candidate[]): M
     grades.sort((a, b) => a - b);
   }
 
+  // Lower median: for an even number of grades, Majority Judgment uses the
+  // lower of the two middle values (and the tie-break below assumes the same).
+  const lowerMedianIndex = (length: number): number =>
+    Math.floor((length - 1) / 2);
+
   const getMedian = (arr: number[]): number => {
     if (arr.length === 0) return 0;
-    return arr[Math.floor(arr.length / 2)];
+    return arr[lowerMedianIndex(arr.length)];
   };
 
   const medianGrades = candidates.map((c) => {
@@ -579,11 +599,13 @@ export function tallyMajorityJudgment(votes: Vote[], candidates: Candidate[]): M
       const aCopy = [...a.grades];
       const bCopy = [...b.grades];
       while (aCopy.length > 0 && bCopy.length > 0) {
-        const aMedian = aCopy[Math.floor(aCopy.length / 2)];
-        const bMedian = bCopy[Math.floor(bCopy.length / 2)];
+        const aIdx = lowerMedianIndex(aCopy.length);
+        const bIdx = lowerMedianIndex(bCopy.length);
+        const aMedian = aCopy[aIdx];
+        const bMedian = bCopy[bIdx];
         if (aMedian !== bMedian) return bMedian - aMedian;
-        aCopy.splice(Math.floor(aCopy.length / 2), 1);
-        bCopy.splice(Math.floor(bCopy.length / 2), 1);
+        aCopy.splice(aIdx, 1);
+        bCopy.splice(bIdx, 1);
       }
       return 0;
     });


### PR DESCRIPTION
## Summary

Fixes five correctness bugs found while scanning the election logic — three in the shared tally algorithms, one ranking-resolution bug, and one front-end vote-corruption bug.

### Bugs fixed

1. **Non-transitive `selectWinner` comparator** (`ElectionUtils.ts`) — the sort comparator broke ties by direct head-to-head matchup, which is non-transitive inside a Condorcet cycle (A>B, B>C, C>A). That violates `Array.sort`'s total-order contract and produced an implementation-defined winner in exactly the cyclic case the function exists to resolve. Replaced with a transitive Copeland-style order (approval → net head-to-head → average margin).

2. **Majority Judgment used the upper median** (`electionTallies.ts`) — `arr[floor(length/2)]` returned the higher of the two middle grades for an even electorate, flipping winners. Standard MJ (and the tie-break loop) use the lower median. Fixed both `getMedian` and the iterative tie-break.

3. **MJ ignored unscored candidates** (`electionTallies.ts`) — a candidate a voter didn't grade was omitted rather than counted, letting a fringe candidate rated by a few get an inflated median. Now every voter contributes a grade for every candidate (ungraded = Reject/0), consistent with the other scored methods.

4. **Condorcet & Ranked Pairs ignored unranked candidates** (`electionTallies.ts`) — the pairwise matrix only counted pairs where both candidates appeared within a ballot, so a dominant candidate on truncated ballots could be missed and no Condorcet winner reported. Added a shared `buildPairwiseMatrix` helper that treats unranked candidates as lowest preference (consistent with `getPairwiseResults`), used by both `tallyCondorcet` and `tallyRankedPairs`.

5. **Ballot ranking reset on real-time updates** (`App.tsx`, `RankedApprovalList.tsx`) — the voter's in-progress ranking was stored in the same `candidates` state used for display, so a real-time snapshot (another voter submitting) would silently reset the ballot. Added a dedicated `ballotRanking` state for submission and made `RankedApprovalList` reconcile incoming candidates (preserve order, append new, drop removed) without discarding the voter's drag order.

## Testing

- **shared-utils: 64/64 tests pass**, including 6 new regression tests (even-median, missing-grade, truncated-ballot Condorcet/Ranked Pairs, cycle `selectWinner` total-order + determinism).
- **Typecheck:** election-site `tsc` output is identical to baseline (the pre-existing errors are unrelated missing-`@repo/ui` resolution and `implicitly any` event handlers) — these changes add zero new type errors.
- `ElectionResults.test.tsx` passes.

## Notes for review

- I deliberately left the spatial-viz Condorcet duplicates (`electionRunner.ts`/`spatialVoting.ts`) untouched — their rankings are always complete, so #4 is latent there and changing them adds risk for no behavior gain.
- The front-end fix (#5) couldn't be exercised against the live Firebase app, so it's worth a manual smoke-test: a ranked-method vote with a second concurrent voter, to confirm the in-progress drag order survives a snapshot.
- Lower-severity items found in the scan but not addressed here: empty-candidate-list crash guards, fabricated `voteCounts` in the viz runners, unseeded `Math.random` in the spatial map, and no-empty-ballot validation in `submitVote`. Happy to do these in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)