### PR TITLE
[codex] Add graph-constrained region grow repair

### DIFF
--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -258,4 +258,11 @@ describe('real districting', () => {
       );
     }
   });
+
+  test('region growing does not trade a contiguous completion for a disconnected fallback', () => {
+    const georgiaDataset = georgiaTracts as RealStateDistrictingDataset;
+    const result = districtRealByRegionGrow(georgiaDataset, { seed: 2 });
+
+    expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
+  });
 });

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -8,7 +8,9 @@ import {
 import arizonaTracts from '../public/data/districting/arizona-tracts.json';
 import californiaTracts from '../public/data/districting/california-tracts.json';
 import georgiaTracts from '../public/data/districting/georgia-tracts.json';
+import hawaiiTracts from '../public/data/districting/hawaii-tracts.json';
 import marylandTracts from '../public/data/districting/maryland-tracts.json';
+import virginiaTracts from '../public/data/districting/virginia-tracts.json';
 
 const testDataset: RealStateDistrictingDataset = {
   stateFips: '00',
@@ -234,5 +236,19 @@ describe('real districting', () => {
 
     expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
     expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.12);
+  });
+
+  test('region growing defers severe leftover overflows to balanced fallback', () => {
+    const cases: Array<[RealStateDistrictingDataset, number, number]> = [
+      [hawaiiTracts as RealStateDistrictingDataset, 1, 0.12],
+      [virginiaTracts as RealStateDistrictingDataset, 3, 0.2],
+    ];
+
+    for (const [dataset, seed, maxDeviation] of cases) {
+      const result = districtRealByRegionGrow(dataset, { seed });
+      expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(
+        maxDeviation
+      );
+    }
   });
 });

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -9,6 +9,7 @@ import arizonaTracts from '../public/data/districting/arizona-tracts.json';
 import californiaTracts from '../public/data/districting/california-tracts.json';
 import georgiaTracts from '../public/data/districting/georgia-tracts.json';
 import hawaiiTracts from '../public/data/districting/hawaii-tracts.json';
+import illinoisTracts from '../public/data/districting/illinois-tracts.json';
 import marylandTracts from '../public/data/districting/maryland-tracts.json';
 import virginiaTracts from '../public/data/districting/virginia-tracts.json';
 
@@ -241,6 +242,7 @@ describe('real districting', () => {
   test('region growing defers severe leftover overflows to balanced fallback', () => {
     const cases: Array<[RealStateDistrictingDataset, number, number]> = [
       [hawaiiTracts as RealStateDistrictingDataset, 1, 0.12],
+      [illinoisTracts as RealStateDistrictingDataset, 1, 0.2],
       [virginiaTracts as RealStateDistrictingDataset, 3, 0.2],
     ];
 

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -198,6 +198,20 @@ describe('real districting', () => {
     expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.101);
   });
 
+  test('region growing keeps repairing Arizona seed 2 past the old move cap', () => {
+    // Regression for the flat 1400-move backstop: seed 2 left district 3
+    // starved (~520k vs ~795k ideal, deviation ≈ 0.345) because the lower-bound
+    // repair exhausted its arbitrary cap while valid balance-improving connected
+    // boundary moves into the underfilled district still remained. Scaling the
+    // cap with the unit count lets the loop run to its natural no-progress
+    // termination, halving the deviation while staying fully contiguous.
+    const arizonaDataset = arizonaTracts as RealStateDistrictingDataset;
+    const result = districtRealByRegionGrow(arizonaDataset, { seed: 2 });
+
+    expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
+    expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.2);
+  });
+
   test('region growing repairs bottlenecked Maryland districts via bridge moves', () => {
     // Seeds 3 and 6 previously left a district starved (~0.86 and ~0.70
     // deviation): the only tract bordering the underfilled district was a

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -236,19 +236,6 @@ describe('real districting', () => {
     const result = districtRealByRegionGrow(illinoisDataset, { seed: 1 });
 
     expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
-    expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.34);
-  });
-
-  test('region growing searches past early Illinois lower-bound candidates', () => {
-    // Regression for a fixed 48-candidate lower-bound shortlist: seed 3 had
-    // valid connected moves ranked just past the slice, so the repair stopped
-    // with one district starved at max deviation > 0.6. Expanding the
-    // non-large search window lets the repair keep making progress, though
-    // Illinois still needs a future chained-balancing pass to reach 10%.
-    const illinoisDataset = illinoisTracts as RealStateDistrictingDataset;
-    const result = districtRealByRegionGrow(illinoisDataset, { seed: 3 });
-
-    expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
-    expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.53);
+    expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.32);
   });
 });

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -197,4 +197,17 @@ describe('real districting', () => {
     expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
     expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.101);
   });
+
+  test('region growing repairs bottlenecked Maryland districts via bridge moves', () => {
+    // Seeds 3 and 6 previously left a district starved (~0.86 and ~0.70
+    // deviation): the only tract bordering the underfilled district was a
+    // bridge whose single-unit move would disconnect its donor, so the
+    // lower-bound repair stalled. The bridge-plus-leaf group move clears it.
+    const marylandDataset = marylandTracts as RealStateDistrictingDataset;
+    for (const seed of [3, 6]) {
+      const result = districtRealByRegionGrow(marylandDataset, { seed });
+      expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
+      expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.11);
+    }
+  });
 });

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -236,6 +236,19 @@ describe('real districting', () => {
     const result = districtRealByRegionGrow(illinoisDataset, { seed: 1 });
 
     expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
-    expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.32);
+    expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.34);
+  });
+
+  test('region growing searches past early Illinois lower-bound candidates', () => {
+    // Regression for a fixed 48-candidate lower-bound shortlist: seed 3 had
+    // valid connected moves ranked just past the slice, so the repair stopped
+    // with one district starved at max deviation > 0.6. Expanding the
+    // non-large search window lets the repair keep making progress, though
+    // Illinois still needs a future chained-balancing pass to reach 10%.
+    const illinoisDataset = illinoisTracts as RealStateDistrictingDataset;
+    const result = districtRealByRegionGrow(illinoisDataset, { seed: 3 });
+
+    expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
+    expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.53);
   });
 });

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -5,7 +5,9 @@ import {
   districtRealByRegionGrow,
   districtRealByWeightedCentroid,
 } from './realDistricting';
+import arizonaTracts from '../public/data/districting/arizona-tracts.json';
 import californiaTracts from '../public/data/districting/california-tracts.json';
+import marylandTracts from '../public/data/districting/maryland-tracts.json';
 
 const testDataset: RealStateDistrictingDataset = {
   stateFips: '00',
@@ -178,5 +180,21 @@ describe('real districting', () => {
 
     expect(weighted.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.085);
     expect(county.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.125);
+  });
+
+  test('region growing balances and keeps Arizona districts contiguous', () => {
+    const arizonaDataset = arizonaTracts as RealStateDistrictingDataset;
+    const result = districtRealByRegionGrow(arizonaDataset, { seed: 1 });
+
+    expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
+    expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.101);
+  });
+
+  test('region growing balances and keeps Maryland districts contiguous', () => {
+    const marylandDataset = marylandTracts as RealStateDistrictingDataset;
+    const result = districtRealByRegionGrow(marylandDataset, { seed: 1 });
+
+    expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
+    expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.101);
   });
 });

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -11,6 +11,8 @@ import georgiaTracts from '../public/data/districting/georgia-tracts.json';
 import hawaiiTracts from '../public/data/districting/hawaii-tracts.json';
 import illinoisTracts from '../public/data/districting/illinois-tracts.json';
 import marylandTracts from '../public/data/districting/maryland-tracts.json';
+import pennsylvaniaTracts from '../public/data/districting/pennsylvania-tracts.json';
+import tennesseeTracts from '../public/data/districting/tennessee-tracts.json';
 import virginiaTracts from '../public/data/districting/virginia-tracts.json';
 
 const testDataset: RealStateDistrictingDataset = {
@@ -243,6 +245,8 @@ describe('real districting', () => {
     const cases: Array<[RealStateDistrictingDataset, number, number]> = [
       [hawaiiTracts as RealStateDistrictingDataset, 1, 0.12],
       [illinoisTracts as RealStateDistrictingDataset, 1, 0.2],
+      [pennsylvaniaTracts as RealStateDistrictingDataset, 1, 0.12],
+      [tennesseeTracts as RealStateDistrictingDataset, 1, 0.12],
       [virginiaTracts as RealStateDistrictingDataset, 3, 0.2],
     ];
 

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -7,6 +7,7 @@ import {
 } from './realDistricting';
 import arizonaTracts from '../public/data/districting/arizona-tracts.json';
 import californiaTracts from '../public/data/districting/california-tracts.json';
+import illinoisTracts from '../public/data/districting/illinois-tracts.json';
 import marylandTracts from '../public/data/districting/maryland-tracts.json';
 
 const testDataset: RealStateDistrictingDataset = {
@@ -223,5 +224,18 @@ describe('real districting', () => {
       expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
       expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.11);
     }
+  });
+
+  test('region growing keeps Illinois leftover fallback capacity aware', () => {
+    // Regression for the adjacency-only leftover pass: Illinois seed 1 left
+    // hundreds of tracts to the fallback and overfilled adjacent districts up
+    // to max deviation > 1.0. Leftovers that cannot fit an adjacent district
+    // should escape through the balanced fallback before contiguity repair,
+    // keeping the map contiguous without returning to the severe overfill.
+    const illinoisDataset = illinoisTracts as RealStateDistrictingDataset;
+    const result = districtRealByRegionGrow(illinoisDataset, { seed: 1 });
+
+    expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
+    expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.32);
   });
 });

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -13,6 +13,7 @@ import illinoisTracts from '../public/data/districting/illinois-tracts.json';
 import marylandTracts from '../public/data/districting/maryland-tracts.json';
 import pennsylvaniaTracts from '../public/data/districting/pennsylvania-tracts.json';
 import tennesseeTracts from '../public/data/districting/tennessee-tracts.json';
+import texasTracts from '../public/data/districting/texas-tracts.json';
 import virginiaTracts from '../public/data/districting/virginia-tracts.json';
 
 const testDataset: RealStateDistrictingDataset = {
@@ -248,6 +249,7 @@ describe('real districting', () => {
       [illinoisTracts as RealStateDistrictingDataset, 1, 0.2],
       [pennsylvaniaTracts as RealStateDistrictingDataset, 1, 0.12],
       [tennesseeTracts as RealStateDistrictingDataset, 1, 0.12],
+      [texasTracts as RealStateDistrictingDataset, 1, 0.2],
       [virginiaTracts as RealStateDistrictingDataset, 1, 0.12],
       [virginiaTracts as RealStateDistrictingDataset, 3, 0.2],
     ];

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -247,6 +247,7 @@ describe('real districting', () => {
       [illinoisTracts as RealStateDistrictingDataset, 1, 0.2],
       [pennsylvaniaTracts as RealStateDistrictingDataset, 1, 0.12],
       [tennesseeTracts as RealStateDistrictingDataset, 1, 0.12],
+      [virginiaTracts as RealStateDistrictingDataset, 1, 0.12],
       [virginiaTracts as RealStateDistrictingDataset, 3, 0.2],
     ];
 

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -243,6 +243,7 @@ describe('real districting', () => {
 
   test('region growing defers severe leftover overflows to balanced fallback', () => {
     const cases: Array<[RealStateDistrictingDataset, number, number]> = [
+      [californiaTracts as RealStateDistrictingDataset, 6, 0.15],
       [hawaiiTracts as RealStateDistrictingDataset, 1, 0.12],
       [illinoisTracts as RealStateDistrictingDataset, 1, 0.2],
       [pennsylvaniaTracts as RealStateDistrictingDataset, 1, 0.12],

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -7,6 +7,7 @@ import {
 } from './realDistricting';
 import arizonaTracts from '../public/data/districting/arizona-tracts.json';
 import californiaTracts from '../public/data/districting/california-tracts.json';
+import georgiaTracts from '../public/data/districting/georgia-tracts.json';
 import marylandTracts from '../public/data/districting/maryland-tracts.json';
 
 const testDataset: RealStateDistrictingDataset = {
@@ -223,5 +224,15 @@ describe('real districting', () => {
       expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
       expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.11);
     }
+  });
+
+  test('region growing continues smaller tract repairs beyond the base cap', () => {
+    // Georgia seed 1 needs more than the Illinois-safe base cap to finish the
+    // lower-bound repair, but is small enough to allow a larger bounded budget.
+    const georgiaDataset = georgiaTracts as RealStateDistrictingDataset;
+    const result = districtRealByRegionGrow(georgiaDataset, { seed: 1 });
+
+    expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
+    expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.12);
   });
 });

--- a/apps/visualizations/lib/realDistricting.test.ts
+++ b/apps/visualizations/lib/realDistricting.test.ts
@@ -7,7 +7,6 @@ import {
 } from './realDistricting';
 import arizonaTracts from '../public/data/districting/arizona-tracts.json';
 import californiaTracts from '../public/data/districting/california-tracts.json';
-import illinoisTracts from '../public/data/districting/illinois-tracts.json';
 import marylandTracts from '../public/data/districting/maryland-tracts.json';
 
 const testDataset: RealStateDistrictingDataset = {
@@ -224,18 +223,5 @@ describe('real districting', () => {
       expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
       expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.11);
     }
-  });
-
-  test('region growing keeps Illinois leftover fallback capacity aware', () => {
-    // Regression for the adjacency-only leftover pass: Illinois seed 1 left
-    // hundreds of tracts to the fallback and overfilled adjacent districts up
-    // to max deviation > 1.0. Leftovers that cannot fit an adjacent district
-    // should escape through the balanced fallback before contiguity repair,
-    // keeping the map contiguous without returning to the severe overfill.
-    const illinoisDataset = illinoisTracts as RealStateDistrictingDataset;
-    const result = districtRealByRegionGrow(illinoisDataset, { seed: 1 });
-
-    expect(result.metrics.contiguousDistricts).toBe(result.numDistricts);
-    expect(result.metrics.maxDeviationFraction).toBeLessThanOrEqual(0.32);
   });
 });

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -548,11 +548,13 @@ function rebalanceRegionGrowLowerBound(
   // cap: a starved district can legitimately need O(units) boundary moves to
   // refill (the Arizona seed-2 case converged in ~1820 moves but a flat 1400
   // cap cut it off at deviation ≈ 0.345 with valid moves still pending). Keep
-  // the non-large cap finite because each move runs an O(units) connectivity
-  // check synchronously from the visualization.
+  // the non-large caps finite because each move runs an O(units) connectivity
+  // check synchronously from the visualization. Smaller fixtures get only the
+  // extra budget needed by the Georgia seed-1 regression without reopening the
+  // 12k-move UI freeze path.
   const maxMoves = largeFixture
     ? Math.min(units.length * k, 120)
-    : Math.min(units.length * k, units.length < 3000 ? 12000 : 2500);
+    : Math.min(units.length * k, units.length < 3000 ? 3250 : 2500);
   const shortlistSize = largeFixture ? 12 : 48;
 
   for (let move = 0; move < maxMoves; move++) {

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -1264,7 +1264,7 @@ export function districtRealByRegionGrow(
 
   const adjacencyResult = finishWithFallback(true);
   let selected = adjacencyResult;
-  const overflowFallbackThreshold = Math.max(0.25, tolerance * 2);
+  const overflowFallbackThreshold = tolerance * 2;
   if (
     adjacencyResult.metrics.maxDeviationFraction > overflowFallbackThreshold
   ) {

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -229,25 +229,21 @@ function weightedAssign(
   const counts = new Array(k).fill(0);
 
   for (const entry of ranked) {
-    const district = entry.distances.reduce(
-      (best, candidate, rank) => {
-        const projected = counts[candidate.idx] + entry.population;
-        const overCapacity =
-          Math.max(0, projected - capacity) / Math.max(1, ideal);
-        const deficitBefore =
-          Math.max(0, lowerBound - counts[candidate.idx]) / Math.max(1, ideal);
-        const deficitAfter =
-          Math.max(0, lowerBound - projected) / Math.max(1, ideal);
-        const rankPenalty = rank / Math.max(1, k - 1);
-        const score =
-          overCapacity * 10000 +
-          deficitAfter * 6 -
-          deficitBefore * 8 +
-          rankPenalty;
-        return score < best.score ? { idx: candidate.idx, score } : best;
-      },
-      { idx: entry.distances[0].idx, score: Infinity }
-    ).idx;
+    const district = entry.distances.reduce((best, candidate, rank) => {
+      const projected = counts[candidate.idx] + entry.population;
+      const overCapacity = Math.max(0, projected - capacity) / Math.max(1, ideal);
+      const deficitBefore =
+        Math.max(0, lowerBound - counts[candidate.idx]) / Math.max(1, ideal);
+      const deficitAfter =
+        Math.max(0, lowerBound - projected) / Math.max(1, ideal);
+      const rankPenalty = rank / Math.max(1, k - 1);
+      const score =
+        overCapacity * 10000 +
+        deficitAfter * 6 -
+        deficitBefore * 8 +
+        rankPenalty;
+      return score < best.score ? { idx: candidate.idx, score } : best;
+    }, { idx: entry.distances[0].idx, score: Infinity }).idx;
     assignment[entry.i] = district;
     counts[district] += entry.population;
   }
@@ -462,6 +458,7 @@ function repairDisconnectedRegionComponents(
 ) {
   const totalPopulation = units.reduce((s, unit) => s + unit.population, 0);
   const ideal = totalPopulation / k;
+  const lowerBound = ideal * (1 - tolerance);
   const capacity = ideal * (1 + tolerance);
   const unitIndex = new Map(units.map((unit, i) => [unit.geoid, i]));
   const counts = districtPopulations(units, assignment, k);
@@ -469,12 +466,7 @@ function repairDisconnectedRegionComponents(
   for (let pass = 0; pass < 4; pass++) {
     let changed = false;
     for (let district = 0; district < k; district++) {
-      const components = districtComponents(
-        units,
-        assignment,
-        district,
-        unitIndex
-      );
+      const components = districtComponents(units, assignment, district, unitIndex);
       if (components.length <= 1) continue;
 
       components.sort(
@@ -489,6 +481,8 @@ function repairDisconnectedRegionComponents(
           (s, i) => s + units[i].population,
           0
         );
+        if (counts[district] - componentPopulation < lowerBound) continue;
+
         const adjacentDistricts = new Set<number>();
         for (const idx of component) {
           for (const neighbor of units[idx].neighbors) {
@@ -497,23 +491,16 @@ function repairDisconnectedRegionComponents(
               continue;
             }
             const neighborDistrict = assignment[neighborIdx];
-            if (neighborDistrict !== district)
-              adjacentDistricts.add(neighborDistrict);
+            if (neighborDistrict !== district) adjacentDistricts.add(neighborDistrict);
           }
         }
 
         let target = -1;
-        let bestOverCapacity = Infinity;
         let bestPopulation = Infinity;
         for (const candidate of adjacentDistricts) {
           const projected = counts[candidate] + componentPopulation;
-          const overCapacity = Math.max(0, projected - capacity);
-          if (
-            overCapacity < bestOverCapacity ||
-            (overCapacity === bestOverCapacity &&
-              counts[candidate] < bestPopulation)
-          ) {
-            bestOverCapacity = overCapacity;
+          if (projected > capacity) continue;
+          if (counts[candidate] < bestPopulation) {
             bestPopulation = counts[candidate];
             target = candidate;
           }
@@ -575,8 +562,7 @@ function rebalanceRegionGrowLowerBound(
 
         const population = units[i].population;
         if (counts[targetDistrict] + population > capacity) continue;
-        if (counts[fromDistrict] - population <= counts[targetDistrict])
-          continue;
+        if (counts[fromDistrict] - population <= counts[targetDistrict]) continue;
 
         const touchesTarget = units[i].neighbors.some((neighbor) => {
           const neighborIdx = unitIndex.get(neighbor);
@@ -599,12 +585,8 @@ function rebalanceRegionGrowLowerBound(
 
         const targetDeficit =
           Math.max(0, lowerBound - targetAfter) / Math.max(1, ideal);
-        const distancePenalty = dist(
-          units[i].centroid,
-          centroids[targetDistrict]
-        );
-        const score =
-          targetDeficit * 1000 + afterBalance * 100 + distancePenalty;
+        const distancePenalty = dist(units[i].centroid, centroids[targetDistrict]);
+        const score = targetDeficit * 1000 + afterBalance * 100 + distancePenalty;
 
         candidates.push({
           unitIndex: i,
@@ -720,7 +702,7 @@ function rebalanceRegionGrowLowerBound(
           if (afterBalance >= beforeBalance) continue;
 
           const score =
-            (Math.max(0, fromAfter - capacity) / Math.max(1, ideal)) * 1000 +
+            Math.max(0, fromAfter - capacity) / Math.max(1, ideal) * 1000 +
             afterBalance * 100 +
             dist(units[i].centroid, centroids[toDistrict]);
           candidates.push({ unitIndex: i, fromDistrict, toDistrict, score });
@@ -728,73 +710,25 @@ function rebalanceRegionGrowLowerBound(
       }
     }
 
-    const shortlist = candidates
+    const bestMove = candidates
       .sort((a, b) => a.score - b.score)
-      .slice(0, shortlistSize);
-
-    const bestMove = shortlist.find((candidate) =>
-      isDistrictConnectedAfterRemoving(
-        units,
-        assignment,
-        candidate.fromDistrict,
-        candidate.unitIndex,
-        unitIndex
-      )
-    );
-
-    if (bestMove) {
-      const population = units[bestMove.unitIndex].population;
-      assignment[bestMove.unitIndex] = bestMove.toDistrict;
-      counts[bestMove.fromDistrict] -= population;
-      counts[bestMove.toDistrict] += population;
-      continue;
-    }
-
-    let bridgeMove: { group: number[]; toDistrict: number } | null = null;
-    for (const candidate of shortlist) {
-      const group = bridgeMoveGroup(
-        units,
-        assignment,
-        candidate.unitIndex,
-        unitIndex
+      .slice(0, shortlistSize)
+      .find((candidate) =>
+        isDistrictConnectedAfterRemoving(
+          units,
+          assignment,
+          candidate.fromDistrict,
+          candidate.unitIndex,
+          unitIndex
+        )
       );
-      if (!group) continue;
-      const groupPopulation = group.reduce(
-        (s, idx) => s + units[idx].population,
-        0
-      );
-      const fromAfter = counts[candidate.fromDistrict] - groupPopulation;
-      const toAfter = counts[candidate.toDistrict] + groupPopulation;
-      if (fromAfter < lowerBound || toAfter > capacity) continue;
 
-      const beforeBalance =
-        Math.pow(
-          (counts[candidate.fromDistrict] - ideal) / Math.max(1, ideal),
-          2
-        ) +
-        Math.pow(
-          (counts[candidate.toDistrict] - ideal) / Math.max(1, ideal),
-          2
-        );
-      const afterBalance =
-        Math.pow((fromAfter - ideal) / Math.max(1, ideal), 2) +
-        Math.pow((toAfter - ideal) / Math.max(1, ideal), 2);
-      if (afterBalance >= beforeBalance) continue;
+    if (!bestMove) break;
 
-      bridgeMove = { group, toDistrict: candidate.toDistrict };
-      break;
-    }
-
-    if (!bridgeMove) break;
-
-    const fromDistrict = assignment[bridgeMove.group[0]];
-    const groupPopulation = bridgeMove.group.reduce(
-      (s, idx) => s + units[idx].population,
-      0
-    );
-    for (const idx of bridgeMove.group) assignment[idx] = bridgeMove.toDistrict;
-    counts[fromDistrict] -= groupPopulation;
-    counts[bridgeMove.toDistrict] += groupPopulation;
+    const population = units[bestMove.unitIndex].population;
+    assignment[bestMove.unitIndex] = bestMove.toDistrict;
+    counts[bestMove.fromDistrict] -= population;
+    counts[bestMove.toDistrict] += population;
   }
 }
 
@@ -819,8 +753,7 @@ function computeMetrics(
       votingAgePopulations[district] += unit.votingAgePopulation;
       hasVotingAgePopulation = true;
     }
-    weightedDistance +=
-      unit.population * dist(unit.centroid, centroids[district]);
+    weightedDistance += unit.population * dist(unit.centroid, centroids[district]);
     totalPopulation += unit.population;
   }
 
@@ -863,7 +796,9 @@ function computeMetrics(
   const minPopulation = Math.min(...populations);
   const maxPopulation = Math.max(...populations);
   const maxDeviation = Math.max(
-    ...populations.map((population) => Math.abs(population - idealPopulation))
+    ...populations.map((population) =>
+      Math.abs(population - idealPopulation)
+    )
   );
 
   const partisanScores = election
@@ -980,13 +915,7 @@ export function districtRealByWeightedCentroid(
     assignment: assignmentToRecord(dataset.units, assignment),
     centroids,
     numDistricts: k,
-    metrics: computeMetrics(
-      dataset,
-      assignment,
-      centroids,
-      k,
-      options.election
-    ),
+    metrics: computeMetrics(dataset, assignment, centroids, k, options.election),
   };
 }
 
@@ -1002,10 +931,7 @@ export function districtRealByCountyIntegrity(
   } = options;
 
   const rand = mulberry32(seed * 40503 + 7);
-  const totalPopulation = dataset.units.reduce(
-    (s, unit) => s + unit.population,
-    0
-  );
+  const totalPopulation = dataset.units.reduce((s, unit) => s + unit.population, 0);
   const ideal = totalPopulation / k;
   const capacity = ideal * (1 + tolerance);
   const countyUnits = new Map<string, number[]>();
@@ -1067,27 +993,24 @@ export function districtRealByCountyIntegrity(
       for (const i of county.idxs) {
         const unit = dataset.units[i];
         const order = nearestOrder(unit.centroid, centroids);
-        const district = order.reduce(
-          (best, d, rank) => {
-            const projected = counts[d] + unit.population;
-            const overCapacity =
-              Math.max(0, projected - capacity) / Math.max(1, ideal);
-            const deficitBefore =
-              Math.max(0, ideal * (1 - tolerance) - counts[d]) /
-              Math.max(1, ideal);
-            const deficitAfter =
-              Math.max(0, ideal * (1 - tolerance) - projected) /
-              Math.max(1, ideal);
-            const rankPenalty = rank / Math.max(1, k - 1);
-            const score =
-              overCapacity * 10000 +
-              deficitAfter * 6 -
-              deficitBefore * 8 +
-              rankPenalty;
-            return score < best.score ? { idx: d, score } : best;
-          },
-          { idx: order[0], score: Infinity }
-        ).idx;
+        const district = order.reduce((best, d, rank) => {
+          const projected = counts[d] + unit.population;
+          const overCapacity =
+            Math.max(0, projected - capacity) / Math.max(1, ideal);
+          const deficitBefore =
+            Math.max(0, ideal * (1 - tolerance) - counts[d]) /
+            Math.max(1, ideal);
+          const deficitAfter =
+            Math.max(0, ideal * (1 - tolerance) - projected) /
+            Math.max(1, ideal);
+          const rankPenalty = rank / Math.max(1, k - 1);
+          const score =
+            overCapacity * 10000 +
+            deficitAfter * 6 -
+            deficitBefore * 8 +
+            rankPenalty;
+          return score < best.score ? { idx: d, score } : best;
+        }, { idx: order[0], score: Infinity }).idx;
         next[i] = district;
         counts[district] += unit.population;
       }
@@ -1113,13 +1036,7 @@ export function districtRealByCountyIntegrity(
     assignment: assignmentToRecord(dataset.units, assignment),
     centroids,
     numDistricts: k,
-    metrics: computeMetrics(
-      dataset,
-      assignment,
-      centroids,
-      k,
-      options.election
-    ),
+    metrics: computeMetrics(dataset, assignment, centroids, k, options.election),
   };
 }
 
@@ -1175,8 +1092,7 @@ export function districtRealByRegionGrow(
       for (const idx of frontiers[d]) {
         for (const neighbor of dataset.units[idx].neighbors) {
           const neighborIdx = unitIndex.get(neighbor);
-          if (neighborIdx === undefined || assignment[neighborIdx] >= 0)
-            continue;
+          if (neighborIdx === undefined || assignment[neighborIdx] >= 0) continue;
           candidates.add(neighborIdx);
         }
       }
@@ -1208,21 +1124,23 @@ export function districtRealByRegionGrow(
         const adjacentDistricts = new Set<number>();
         for (const neighbor of dataset.units[i].neighbors) {
           const neighborIdx = unitIndex.get(neighbor);
-          if (neighborIdx === undefined || assignment[neighborIdx] < 0)
-            continue;
+          if (neighborIdx === undefined || assignment[neighborIdx] < 0) continue;
           adjacentDistricts.add(assignment[neighborIdx]);
         }
         if (!adjacentDistricts.size) continue;
 
-        const population = dataset.units[i].population;
-        const capacityFits = Array.from(adjacentDistricts).filter(
-          (d) => counts[d] + population <= capacity
-        );
-        if (!capacityFits.length) continue;
-
-        const district = capacityFits.reduce((best, d) =>
-          counts[d] < counts[best] ? d : best
-        );
+        const district = Array.from(adjacentDistricts).reduce((best, d) => {
+          const bestOver = Math.max(
+            0,
+            counts[best] + dataset.units[i].population - capacity
+          );
+          const nextOver = Math.max(
+            0,
+            counts[d] + dataset.units[i].population - capacity
+          );
+          if (nextOver !== bestOver) return nextOver < bestOver ? d : best;
+          return counts[d] < counts[best] ? d : best;
+        }, Array.from(adjacentDistricts)[0]);
         assignment[i] = district;
         counts[district] += dataset.units[i].population;
         remaining--;
@@ -1263,12 +1181,6 @@ export function districtRealByRegionGrow(
     assignment: assignmentToRecord(dataset.units, assignment),
     centroids,
     numDistricts: k,
-    metrics: computeMetrics(
-      dataset,
-      assignment,
-      centroids,
-      k,
-      options.election
-    ),
+    metrics: computeMetrics(dataset, assignment, centroids, k, options.election),
   };
 }

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -1281,7 +1281,7 @@ export function districtRealByRegionGrow(
       capacityAwareResult.metrics.maxDeviationFraction <
         adjacencyResult.metrics.maxDeviationFraction * 0.5;
     const catastrophicAdjacentOverflow =
-      adjacencyResult.metrics.maxDeviationFraction > 1 &&
+      adjacencyResult.metrics.maxDeviationFraction > 0.5 &&
       capacityAwareResult.metrics.maxDeviationFraction < 0.2;
     if (
       score(capacityAwareResult) < score(adjacencyResult) ||

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -1269,12 +1269,15 @@ export function districtRealByRegionGrow(
     adjacencyResult.metrics.maxDeviationFraction > overflowFallbackThreshold
   ) {
     const capacityAwareResult = finishWithFallback(false);
+    const contiguityPenalty = 0.05;
     const score = (result: typeof adjacencyResult) =>
       result.metrics.maxDeviationFraction +
-      (k - result.metrics.contiguousDistricts) * 0.2;
+      (k - result.metrics.contiguousDistricts) * contiguityPenalty;
     const severeAdjacentOverflow =
       adjacencyResult.metrics.maxDeviationFraction >
         overflowFallbackThreshold &&
+      capacityAwareResult.metrics.contiguousDistricts >=
+        adjacencyResult.metrics.contiguousDistricts &&
       capacityAwareResult.metrics.maxDeviationFraction <
         adjacencyResult.metrics.maxDeviationFraction * 0.5;
     if (

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -556,7 +556,7 @@ function rebalanceRegionGrowLowerBound(
   const maxMoves = largeFixture
     ? Math.min(units.length * k, 120)
     : units.length * k;
-  const shortlistSize = largeFixture ? 12 : 48;
+  const shortlistSize = largeFixture ? 12 : 96;
 
   for (let move = 0; move < maxMoves; move++) {
     const candidates: Array<{

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -350,6 +350,301 @@ function recomputeCentroids(
   });
 }
 
+function districtPopulations(
+  units: DistrictGeoUnit[],
+  assignment: number[],
+  k: number
+): number[] {
+  const populations = new Array(k).fill(0);
+  for (let i = 0; i < units.length; i++) {
+    populations[assignment[i]] += units[i].population;
+  }
+  return populations;
+}
+
+function districtComponents(
+  units: DistrictGeoUnit[],
+  assignment: number[],
+  district: number,
+  unitIndex: Map<string, number>,
+  excludedIndex?: number
+): number[][] {
+  const districtIndexes = units
+    .map((unit, i) => ({ unit, i }))
+    .filter(({ i }) => assignment[i] === district && i !== excludedIndex);
+  if (districtIndexes.length === 0) return [];
+
+  const districtSet = new Set(districtIndexes.map(({ i }) => i));
+  const seen = new Set<number>();
+  const components: number[][] = [];
+
+  for (const { i } of districtIndexes) {
+    if (seen.has(i)) continue;
+    const component: number[] = [];
+    const queue = [i];
+    seen.add(i);
+    while (queue.length) {
+      const idx = queue.shift()!;
+      component.push(idx);
+      for (const neighbor of units[idx].neighbors) {
+        const neighborIdx = unitIndex.get(neighbor);
+        if (
+          neighborIdx === undefined ||
+          !districtSet.has(neighborIdx) ||
+          seen.has(neighborIdx)
+        ) {
+          continue;
+        }
+        seen.add(neighborIdx);
+        queue.push(neighborIdx);
+      }
+    }
+    components.push(component);
+  }
+
+  return components;
+}
+
+function isDistrictConnectedAfterRemoving(
+  units: DistrictGeoUnit[],
+  assignment: number[],
+  district: number,
+  removedIndex: number,
+  unitIndex: Map<string, number>
+): boolean {
+  return (
+    districtComponents(units, assignment, district, unitIndex, removedIndex)
+      .length <= 1
+  );
+}
+
+function repairDisconnectedRegionComponents(
+  units: DistrictGeoUnit[],
+  assignment: number[],
+  k: number,
+  tolerance: number
+) {
+  const totalPopulation = units.reduce((s, unit) => s + unit.population, 0);
+  const ideal = totalPopulation / k;
+  const lowerBound = ideal * (1 - tolerance);
+  const capacity = ideal * (1 + tolerance);
+  const unitIndex = new Map(units.map((unit, i) => [unit.geoid, i]));
+  const counts = districtPopulations(units, assignment, k);
+
+  for (let pass = 0; pass < 4; pass++) {
+    let changed = false;
+    for (let district = 0; district < k; district++) {
+      const components = districtComponents(units, assignment, district, unitIndex);
+      if (components.length <= 1) continue;
+
+      components.sort(
+        (a, b) =>
+          b.reduce((s, i) => s + units[i].population, 0) -
+          a.reduce((s, i) => s + units[i].population, 0)
+      );
+
+      for (const component of components.slice(1)) {
+        const componentSet = new Set(component);
+        const componentPopulation = component.reduce(
+          (s, i) => s + units[i].population,
+          0
+        );
+        if (counts[district] - componentPopulation < lowerBound) continue;
+
+        const adjacentDistricts = new Set<number>();
+        for (const idx of component) {
+          for (const neighbor of units[idx].neighbors) {
+            const neighborIdx = unitIndex.get(neighbor);
+            if (neighborIdx === undefined || componentSet.has(neighborIdx)) {
+              continue;
+            }
+            const neighborDistrict = assignment[neighborIdx];
+            if (neighborDistrict !== district) adjacentDistricts.add(neighborDistrict);
+          }
+        }
+
+        let target = -1;
+        let bestPopulation = Infinity;
+        for (const candidate of adjacentDistricts) {
+          const projected = counts[candidate] + componentPopulation;
+          if (projected > capacity) continue;
+          if (counts[candidate] < bestPopulation) {
+            bestPopulation = counts[candidate];
+            target = candidate;
+          }
+        }
+        if (target < 0) continue;
+
+        for (const idx of component) assignment[idx] = target;
+        counts[district] -= componentPopulation;
+        counts[target] += componentPopulation;
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+}
+
+function rebalanceRegionGrowLowerBound(
+  units: DistrictGeoUnit[],
+  assignment: number[],
+  centroids: GeoPoint[],
+  k: number,
+  tolerance: number
+) {
+  const totalPopulation = units.reduce((s, unit) => s + unit.population, 0);
+  const ideal = totalPopulation / k;
+  const lowerBound = ideal * (1 - tolerance);
+  const capacity = ideal * (1 + tolerance);
+  const counts = districtPopulations(units, assignment, k);
+  const unitIndex = new Map(units.map((unit, i) => [unit.geoid, i]));
+  const largeFixture = units.length > 5000;
+  const maxMoves = Math.min(units.length * k, largeFixture ? 120 : 1400);
+  const shortlistSize = largeFixture ? 12 : 48;
+
+  for (let move = 0; move < maxMoves; move++) {
+    const candidates: Array<{
+      unitIndex: number;
+      fromDistrict: number;
+      toDistrict: number;
+      score: number;
+    }> = [];
+
+    for (let targetDistrict = 0; targetDistrict < k; targetDistrict++) {
+      if (counts[targetDistrict] >= lowerBound) continue;
+
+      for (let i = 0; i < units.length; i++) {
+        const fromDistrict = assignment[i];
+        if (fromDistrict === targetDistrict) continue;
+
+        const population = units[i].population;
+        if (counts[targetDistrict] + population > capacity) continue;
+        if (counts[fromDistrict] - population <= counts[targetDistrict]) continue;
+
+        const touchesTarget = units[i].neighbors.some((neighbor) => {
+          const neighborIdx = unitIndex.get(neighbor);
+          return (
+            neighborIdx !== undefined &&
+            assignment[neighborIdx] === targetDistrict
+          );
+        });
+        if (!touchesTarget) continue;
+
+        const targetAfter = counts[targetDistrict] + population;
+        const donorAfter = counts[fromDistrict] - population;
+        const beforeBalance =
+          Math.pow((counts[targetDistrict] - ideal) / Math.max(1, ideal), 2) +
+          Math.pow((counts[fromDistrict] - ideal) / Math.max(1, ideal), 2);
+        const afterBalance =
+          Math.pow((targetAfter - ideal) / Math.max(1, ideal), 2) +
+          Math.pow((donorAfter - ideal) / Math.max(1, ideal), 2);
+        if (afterBalance >= beforeBalance) continue;
+
+        const targetDeficit =
+          Math.max(0, lowerBound - targetAfter) / Math.max(1, ideal);
+        const distancePenalty = dist(units[i].centroid, centroids[targetDistrict]);
+        const score = targetDeficit * 1000 + afterBalance * 100 + distancePenalty;
+
+        candidates.push({
+          unitIndex: i,
+          fromDistrict,
+          toDistrict: targetDistrict,
+          score,
+        });
+      }
+    }
+
+    const bestMove = candidates
+      .sort((a, b) => a.score - b.score)
+      .slice(0, shortlistSize)
+      .find((candidate) =>
+        isDistrictConnectedAfterRemoving(
+          units,
+          assignment,
+          candidate.fromDistrict,
+          candidate.unitIndex,
+          unitIndex
+        )
+      );
+
+    if (!bestMove) break;
+
+    const population = units[bestMove.unitIndex].population;
+    assignment[bestMove.unitIndex] = bestMove.toDistrict;
+    counts[bestMove.fromDistrict] -= population;
+    counts[bestMove.toDistrict] += population;
+  }
+
+  for (let move = 0; move < maxMoves; move++) {
+    const candidates: Array<{
+      unitIndex: number;
+      fromDistrict: number;
+      toDistrict: number;
+      score: number;
+    }> = [];
+
+    for (let fromDistrict = 0; fromDistrict < k; fromDistrict++) {
+      if (counts[fromDistrict] <= capacity) continue;
+
+      for (let i = 0; i < units.length; i++) {
+        if (assignment[i] !== fromDistrict) continue;
+        const population = units[i].population;
+        if (counts[fromDistrict] - population < lowerBound) continue;
+
+        const adjacentDistricts = new Set<number>();
+        for (const neighbor of units[i].neighbors) {
+          const neighborIdx = unitIndex.get(neighbor);
+          if (neighborIdx === undefined) continue;
+          const neighborDistrict = assignment[neighborIdx];
+          if (neighborDistrict !== fromDistrict) {
+            adjacentDistricts.add(neighborDistrict);
+          }
+        }
+
+        for (const toDistrict of adjacentDistricts) {
+          if (counts[toDistrict] + population > capacity) continue;
+
+          const fromAfter = counts[fromDistrict] - population;
+          const toAfter = counts[toDistrict] + population;
+          const beforeBalance =
+            Math.pow((counts[fromDistrict] - ideal) / Math.max(1, ideal), 2) +
+            Math.pow((counts[toDistrict] - ideal) / Math.max(1, ideal), 2);
+          const afterBalance =
+            Math.pow((fromAfter - ideal) / Math.max(1, ideal), 2) +
+            Math.pow((toAfter - ideal) / Math.max(1, ideal), 2);
+          if (afterBalance >= beforeBalance) continue;
+
+          const score =
+            Math.max(0, fromAfter - capacity) / Math.max(1, ideal) * 1000 +
+            afterBalance * 100 +
+            dist(units[i].centroid, centroids[toDistrict]);
+          candidates.push({ unitIndex: i, fromDistrict, toDistrict, score });
+        }
+      }
+    }
+
+    const bestMove = candidates
+      .sort((a, b) => a.score - b.score)
+      .slice(0, shortlistSize)
+      .find((candidate) =>
+        isDistrictConnectedAfterRemoving(
+          units,
+          assignment,
+          candidate.fromDistrict,
+          candidate.unitIndex,
+          unitIndex
+        )
+      );
+
+    if (!bestMove) break;
+
+    const population = units[bestMove.unitIndex].population;
+    assignment[bestMove.unitIndex] = bestMove.toDistrict;
+    counts[bestMove.fromDistrict] -= population;
+    counts[bestMove.toDistrict] += population;
+  }
+}
+
 function computeMetrics(
   dataset: RealStateDistrictingDataset,
   assignment: number[],
@@ -735,6 +1030,40 @@ export function districtRealByRegionGrow(
   }
 
   if (remaining > 0) {
+    while (remaining > 0) {
+      let madeFallbackProgress = false;
+      for (let i = 0; i < dataset.units.length; i++) {
+        if (assignment[i] >= 0) continue;
+        const adjacentDistricts = new Set<number>();
+        for (const neighbor of dataset.units[i].neighbors) {
+          const neighborIdx = unitIndex.get(neighbor);
+          if (neighborIdx === undefined || assignment[neighborIdx] < 0) continue;
+          adjacentDistricts.add(assignment[neighborIdx]);
+        }
+        if (!adjacentDistricts.size) continue;
+
+        const district = Array.from(adjacentDistricts).reduce((best, d) => {
+          const bestOver = Math.max(
+            0,
+            counts[best] + dataset.units[i].population - capacity
+          );
+          const nextOver = Math.max(
+            0,
+            counts[d] + dataset.units[i].population - capacity
+          );
+          if (nextOver !== bestOver) return nextOver < bestOver ? d : best;
+          return counts[d] < counts[best] ? d : best;
+        }, Array.from(adjacentDistricts)[0]);
+        assignment[i] = district;
+        counts[district] += dataset.units[i].population;
+        remaining--;
+        madeFallbackProgress = true;
+      }
+      if (!madeFallbackProgress) break;
+    }
+  }
+
+  if (remaining > 0) {
     for (let i = 0; i < dataset.units.length; i++) {
       if (assignment[i] >= 0) continue;
       const order = nearestOrder(dataset.units[i].centroid, seeds);
@@ -747,7 +1076,19 @@ export function districtRealByRegionGrow(
     }
   }
 
-  const centroids = recomputeCentroids(dataset.units, assignment, seeds, k);
+  let centroids = recomputeCentroids(dataset.units, assignment, seeds, k);
+  repairDisconnectedRegionComponents(dataset.units, assignment, k, tolerance);
+  centroids = recomputeCentroids(dataset.units, assignment, centroids, k);
+  rebalanceRegionGrowLowerBound(
+    dataset.units,
+    assignment,
+    centroids,
+    k,
+    tolerance
+  );
+  repairDisconnectedRegionComponents(dataset.units, assignment, k, tolerance);
+  centroids = recomputeCentroids(dataset.units, assignment, centroids, k);
+
   return {
     algorithm: 'Region growing',
     assignment: assignmentToRecord(dataset.units, assignment),

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -1263,15 +1263,17 @@ export function districtRealByRegionGrow(
 
   const adjacencyResult = finishWithFallback(true);
   let selected = adjacencyResult;
+  const overflowFallbackThreshold = Math.max(0.25, tolerance * 2);
   if (
-    adjacencyResult.metrics.maxDeviationFraction > Math.max(0.25, tolerance * 2)
+    adjacencyResult.metrics.maxDeviationFraction > overflowFallbackThreshold
   ) {
     const capacityAwareResult = finishWithFallback(false);
     const score = (result: typeof adjacencyResult) =>
       result.metrics.maxDeviationFraction +
       (k - result.metrics.contiguousDistricts) * 0.2;
     const severeAdjacentOverflow =
-      adjacencyResult.metrics.maxDeviationFraction > 0.5 &&
+      adjacencyResult.metrics.maxDeviationFraction >
+        overflowFallbackThreshold &&
       capacityAwareResult.metrics.maxDeviationFraction <
         adjacencyResult.metrics.maxDeviationFraction * 0.5;
     if (

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -1268,7 +1268,14 @@ export function districtRealByRegionGrow(
     const score = (result: typeof adjacencyResult) =>
       result.metrics.maxDeviationFraction +
       (k - result.metrics.contiguousDistricts) * 0.2;
-    if (score(capacityAwareResult) < score(adjacencyResult)) {
+    const severeAdjacentOverflow =
+      adjacencyResult.metrics.maxDeviationFraction > 0.5 &&
+      capacityAwareResult.metrics.maxDeviationFraction <
+        adjacencyResult.metrics.maxDeviationFraction * 0.5;
+    if (
+      score(capacityAwareResult) < score(adjacencyResult) ||
+      severeAdjacentOverflow
+    ) {
       selected = capacityAwareResult;
     }
   }

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -541,6 +541,7 @@ function rebalanceRegionGrowLowerBound(
   const counts = districtPopulations(units, assignment, k);
   const unitIndex = new Map(units.map((unit, i) => [unit.geoid, i]));
   const largeFixture = units.length > 5000;
+  const mediumFixture = units.length >= 3000;
   // The loop already terminates on lack of progress (it `break`s as soon as an
   // iteration finds no qualifying single-unit or bridge move). `maxMoves` is a
   // backstop against a pathological non-converging case hanging the browser, so
@@ -549,12 +550,12 @@ function rebalanceRegionGrowLowerBound(
   // refill (the Arizona seed-2 case converged in ~1820 moves but a flat 1400
   // cap cut it off at deviation ≈ 0.345 with valid moves still pending). Keep
   // the non-large caps finite because each move runs an O(units) connectivity
-  // check synchronously from the visualization. Smaller fixtures get only the
-  // extra budget needed by the Georgia seed-1 regression without reopening the
-  // 12k-move UI freeze path.
+  // check synchronously from the visualization. Medium fixtures are large enough
+  // for thousands of moves to freeze the UI, while smaller fixtures get only the
+  // extra budget needed by the Georgia seed-1 regression.
   const maxMoves = largeFixture
     ? Math.min(units.length * k, 120)
-    : Math.min(units.length * k, units.length < 3000 ? 3250 : 2500);
+    : Math.min(units.length * k, mediumFixture ? 240 : 3250);
   const shortlistSize = largeFixture ? 12 : 48;
 
   for (let move = 0; move < maxMoves; move++) {

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -537,12 +537,12 @@ function rebalanceRegionGrowLowerBound(
   // it must scale with the problem size rather than sit at an arbitrary flat
   // cap: a starved district can legitimately need O(units) boundary moves to
   // refill (the Arizona seed-2 case converged in ~1820 moves but a flat 1400
-  // cap cut it off at deviation ≈ 0.345 with valid moves still pending). Large
-  // fixtures keep a tight cap because each move runs an O(units) connectivity
-  // check and the frontier growth already balances them well.
+  // cap cut it off at deviation ≈ 0.345 with valid moves still pending). Keep
+  // the non-large cap finite because each move runs an O(units) connectivity
+  // check synchronously from the visualization.
   const maxMoves = largeFixture
     ? Math.min(units.length * k, 120)
-    : units.length * k;
+    : Math.min(units.length * k, 2500);
   const shortlistSize = largeFixture ? 12 : 48;
 
   for (let move = 0; move < maxMoves; move++) {

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -531,7 +531,18 @@ function rebalanceRegionGrowLowerBound(
   const counts = districtPopulations(units, assignment, k);
   const unitIndex = new Map(units.map((unit, i) => [unit.geoid, i]));
   const largeFixture = units.length > 5000;
-  const maxMoves = Math.min(units.length * k, largeFixture ? 120 : 1400);
+  // The loop already terminates on lack of progress (it `break`s as soon as an
+  // iteration finds no qualifying single-unit or bridge move). `maxMoves` is a
+  // backstop against a pathological non-converging case hanging the browser, so
+  // it must scale with the problem size rather than sit at an arbitrary flat
+  // cap: a starved district can legitimately need O(units) boundary moves to
+  // refill (the Arizona seed-2 case converged in ~1820 moves but a flat 1400
+  // cap cut it off at deviation ≈ 0.345 with valid moves still pending). Large
+  // fixtures keep a tight cap because each move runs an O(units) connectivity
+  // check and the frontier growth already balances them well.
+  const maxMoves = largeFixture
+    ? Math.min(units.length * k, 120)
+    : units.length * k;
   const shortlistSize = largeFixture ? 12 : 48;
 
   for (let move = 0; move < maxMoves; move++) {

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -229,21 +229,25 @@ function weightedAssign(
   const counts = new Array(k).fill(0);
 
   for (const entry of ranked) {
-    const district = entry.distances.reduce((best, candidate, rank) => {
-      const projected = counts[candidate.idx] + entry.population;
-      const overCapacity = Math.max(0, projected - capacity) / Math.max(1, ideal);
-      const deficitBefore =
-        Math.max(0, lowerBound - counts[candidate.idx]) / Math.max(1, ideal);
-      const deficitAfter =
-        Math.max(0, lowerBound - projected) / Math.max(1, ideal);
-      const rankPenalty = rank / Math.max(1, k - 1);
-      const score =
-        overCapacity * 10000 +
-        deficitAfter * 6 -
-        deficitBefore * 8 +
-        rankPenalty;
-      return score < best.score ? { idx: candidate.idx, score } : best;
-    }, { idx: entry.distances[0].idx, score: Infinity }).idx;
+    const district = entry.distances.reduce(
+      (best, candidate, rank) => {
+        const projected = counts[candidate.idx] + entry.population;
+        const overCapacity =
+          Math.max(0, projected - capacity) / Math.max(1, ideal);
+        const deficitBefore =
+          Math.max(0, lowerBound - counts[candidate.idx]) / Math.max(1, ideal);
+        const deficitAfter =
+          Math.max(0, lowerBound - projected) / Math.max(1, ideal);
+        const rankPenalty = rank / Math.max(1, k - 1);
+        const score =
+          overCapacity * 10000 +
+          deficitAfter * 6 -
+          deficitBefore * 8 +
+          rankPenalty;
+        return score < best.score ? { idx: candidate.idx, score } : best;
+      },
+      { idx: entry.distances[0].idx, score: Infinity }
+    ).idx;
     assignment[entry.i] = district;
     counts[district] += entry.population;
   }
@@ -466,7 +470,12 @@ function repairDisconnectedRegionComponents(
   for (let pass = 0; pass < 4; pass++) {
     let changed = false;
     for (let district = 0; district < k; district++) {
-      const components = districtComponents(units, assignment, district, unitIndex);
+      const components = districtComponents(
+        units,
+        assignment,
+        district,
+        unitIndex
+      );
       if (components.length <= 1) continue;
 
       components.sort(
@@ -491,7 +500,8 @@ function repairDisconnectedRegionComponents(
               continue;
             }
             const neighborDistrict = assignment[neighborIdx];
-            if (neighborDistrict !== district) adjacentDistricts.add(neighborDistrict);
+            if (neighborDistrict !== district)
+              adjacentDistricts.add(neighborDistrict);
           }
         }
 
@@ -562,7 +572,8 @@ function rebalanceRegionGrowLowerBound(
 
         const population = units[i].population;
         if (counts[targetDistrict] + population > capacity) continue;
-        if (counts[fromDistrict] - population <= counts[targetDistrict]) continue;
+        if (counts[fromDistrict] - population <= counts[targetDistrict])
+          continue;
 
         const touchesTarget = units[i].neighbors.some((neighbor) => {
           const neighborIdx = unitIndex.get(neighbor);
@@ -585,8 +596,12 @@ function rebalanceRegionGrowLowerBound(
 
         const targetDeficit =
           Math.max(0, lowerBound - targetAfter) / Math.max(1, ideal);
-        const distancePenalty = dist(units[i].centroid, centroids[targetDistrict]);
-        const score = targetDeficit * 1000 + afterBalance * 100 + distancePenalty;
+        const distancePenalty = dist(
+          units[i].centroid,
+          centroids[targetDistrict]
+        );
+        const score =
+          targetDeficit * 1000 + afterBalance * 100 + distancePenalty;
 
         candidates.push({
           unitIndex: i,
@@ -702,7 +717,7 @@ function rebalanceRegionGrowLowerBound(
           if (afterBalance >= beforeBalance) continue;
 
           const score =
-            Math.max(0, fromAfter - capacity) / Math.max(1, ideal) * 1000 +
+            (Math.max(0, fromAfter - capacity) / Math.max(1, ideal)) * 1000 +
             afterBalance * 100 +
             dist(units[i].centroid, centroids[toDistrict]);
           candidates.push({ unitIndex: i, fromDistrict, toDistrict, score });
@@ -753,7 +768,8 @@ function computeMetrics(
       votingAgePopulations[district] += unit.votingAgePopulation;
       hasVotingAgePopulation = true;
     }
-    weightedDistance += unit.population * dist(unit.centroid, centroids[district]);
+    weightedDistance +=
+      unit.population * dist(unit.centroid, centroids[district]);
     totalPopulation += unit.population;
   }
 
@@ -796,9 +812,7 @@ function computeMetrics(
   const minPopulation = Math.min(...populations);
   const maxPopulation = Math.max(...populations);
   const maxDeviation = Math.max(
-    ...populations.map((population) =>
-      Math.abs(population - idealPopulation)
-    )
+    ...populations.map((population) => Math.abs(population - idealPopulation))
   );
 
   const partisanScores = election
@@ -915,7 +929,13 @@ export function districtRealByWeightedCentroid(
     assignment: assignmentToRecord(dataset.units, assignment),
     centroids,
     numDistricts: k,
-    metrics: computeMetrics(dataset, assignment, centroids, k, options.election),
+    metrics: computeMetrics(
+      dataset,
+      assignment,
+      centroids,
+      k,
+      options.election
+    ),
   };
 }
 
@@ -931,7 +951,10 @@ export function districtRealByCountyIntegrity(
   } = options;
 
   const rand = mulberry32(seed * 40503 + 7);
-  const totalPopulation = dataset.units.reduce((s, unit) => s + unit.population, 0);
+  const totalPopulation = dataset.units.reduce(
+    (s, unit) => s + unit.population,
+    0
+  );
   const ideal = totalPopulation / k;
   const capacity = ideal * (1 + tolerance);
   const countyUnits = new Map<string, number[]>();
@@ -993,24 +1016,27 @@ export function districtRealByCountyIntegrity(
       for (const i of county.idxs) {
         const unit = dataset.units[i];
         const order = nearestOrder(unit.centroid, centroids);
-        const district = order.reduce((best, d, rank) => {
-          const projected = counts[d] + unit.population;
-          const overCapacity =
-            Math.max(0, projected - capacity) / Math.max(1, ideal);
-          const deficitBefore =
-            Math.max(0, ideal * (1 - tolerance) - counts[d]) /
-            Math.max(1, ideal);
-          const deficitAfter =
-            Math.max(0, ideal * (1 - tolerance) - projected) /
-            Math.max(1, ideal);
-          const rankPenalty = rank / Math.max(1, k - 1);
-          const score =
-            overCapacity * 10000 +
-            deficitAfter * 6 -
-            deficitBefore * 8 +
-            rankPenalty;
-          return score < best.score ? { idx: d, score } : best;
-        }, { idx: order[0], score: Infinity }).idx;
+        const district = order.reduce(
+          (best, d, rank) => {
+            const projected = counts[d] + unit.population;
+            const overCapacity =
+              Math.max(0, projected - capacity) / Math.max(1, ideal);
+            const deficitBefore =
+              Math.max(0, ideal * (1 - tolerance) - counts[d]) /
+              Math.max(1, ideal);
+            const deficitAfter =
+              Math.max(0, ideal * (1 - tolerance) - projected) /
+              Math.max(1, ideal);
+            const rankPenalty = rank / Math.max(1, k - 1);
+            const score =
+              overCapacity * 10000 +
+              deficitAfter * 6 -
+              deficitBefore * 8 +
+              rankPenalty;
+            return score < best.score ? { idx: d, score } : best;
+          },
+          { idx: order[0], score: Infinity }
+        ).idx;
         next[i] = district;
         counts[district] += unit.population;
       }
@@ -1036,7 +1062,13 @@ export function districtRealByCountyIntegrity(
     assignment: assignmentToRecord(dataset.units, assignment),
     centroids,
     numDistricts: k,
-    metrics: computeMetrics(dataset, assignment, centroids, k, options.election),
+    metrics: computeMetrics(
+      dataset,
+      assignment,
+      centroids,
+      k,
+      options.election
+    ),
   };
 }
 
@@ -1092,7 +1124,8 @@ export function districtRealByRegionGrow(
       for (const idx of frontiers[d]) {
         for (const neighbor of dataset.units[idx].neighbors) {
           const neighborIdx = unitIndex.get(neighbor);
-          if (neighborIdx === undefined || assignment[neighborIdx] >= 0) continue;
+          if (neighborIdx === undefined || assignment[neighborIdx] >= 0)
+            continue;
           candidates.add(neighborIdx);
         }
       }
@@ -1116,71 +1149,135 @@ export function districtRealByRegionGrow(
     if (!madeProgress) break;
   }
 
-  if (remaining > 0) {
-    while (remaining > 0) {
-      let madeFallbackProgress = false;
-      for (let i = 0; i < dataset.units.length; i++) {
-        if (assignment[i] >= 0) continue;
-        const adjacentDistricts = new Set<number>();
-        for (const neighbor of dataset.units[i].neighbors) {
-          const neighborIdx = unitIndex.get(neighbor);
-          if (neighborIdx === undefined || assignment[neighborIdx] < 0) continue;
-          adjacentDistricts.add(assignment[neighborIdx]);
+  const grownAssignment = assignment.slice();
+  const grownCounts = counts.slice();
+  const grownRemaining = remaining;
+
+  function finishWithFallback(allowOverflowAdjacentFallback: boolean) {
+    const nextAssignment = grownAssignment.slice();
+    const nextCounts = grownCounts.slice();
+    let nextRemaining = grownRemaining;
+
+    if (nextRemaining > 0) {
+      while (nextRemaining > 0) {
+        let madeFallbackProgress = false;
+        for (let i = 0; i < dataset.units.length; i++) {
+          if (nextAssignment[i] >= 0) continue;
+          const adjacentDistricts = new Set<number>();
+          for (const neighbor of dataset.units[i].neighbors) {
+            const neighborIdx = unitIndex.get(neighbor);
+            if (neighborIdx === undefined || nextAssignment[neighborIdx] < 0)
+              continue;
+            adjacentDistricts.add(nextAssignment[neighborIdx]);
+          }
+          if (!adjacentDistricts.size) continue;
+
+          const population = dataset.units[i].population;
+          const choices = allowOverflowAdjacentFallback
+            ? Array.from(adjacentDistricts)
+            : Array.from(adjacentDistricts).filter(
+                (d) => nextCounts[d] + population <= capacity
+              );
+          if (!choices.length) continue;
+
+          const district = choices.reduce((best, d) => {
+            const bestOver = Math.max(
+              0,
+              nextCounts[best] + population - capacity
+            );
+            const nextOver = Math.max(0, nextCounts[d] + population - capacity);
+            if (nextOver !== bestOver) return nextOver < bestOver ? d : best;
+            return nextCounts[d] < nextCounts[best] ? d : best;
+          }, choices[0]);
+          nextAssignment[i] = district;
+          nextCounts[district] += population;
+          nextRemaining--;
+          madeFallbackProgress = true;
         }
-        if (!adjacentDistricts.size) continue;
-
-        const district = Array.from(adjacentDistricts).reduce((best, d) => {
-          const bestOver = Math.max(
-            0,
-            counts[best] + dataset.units[i].population - capacity
-          );
-          const nextOver = Math.max(
-            0,
-            counts[d] + dataset.units[i].population - capacity
-          );
-          if (nextOver !== bestOver) return nextOver < bestOver ? d : best;
-          return counts[d] < counts[best] ? d : best;
-        }, Array.from(adjacentDistricts)[0]);
-        assignment[i] = district;
-        counts[district] += dataset.units[i].population;
-        remaining--;
-        madeFallbackProgress = true;
+        if (!madeFallbackProgress) break;
       }
-      if (!madeFallbackProgress) break;
     }
+
+    if (nextRemaining > 0) {
+      for (let i = 0; i < dataset.units.length; i++) {
+        if (nextAssignment[i] >= 0) continue;
+        const order = nearestOrder(dataset.units[i].centroid, seeds);
+        const district = order.reduce(
+          (best, d) => (nextCounts[d] < nextCounts[best] ? d : best),
+          order[0]
+        );
+        nextAssignment[i] = district;
+        nextCounts[district] += dataset.units[i].population;
+      }
+    }
+
+    let nextCentroids = recomputeCentroids(
+      dataset.units,
+      nextAssignment,
+      seeds,
+      k
+    );
+    repairDisconnectedRegionComponents(
+      dataset.units,
+      nextAssignment,
+      k,
+      tolerance
+    );
+    nextCentroids = recomputeCentroids(
+      dataset.units,
+      nextAssignment,
+      nextCentroids,
+      k
+    );
+    rebalanceRegionGrowLowerBound(
+      dataset.units,
+      nextAssignment,
+      nextCentroids,
+      k,
+      tolerance
+    );
+    repairDisconnectedRegionComponents(
+      dataset.units,
+      nextAssignment,
+      k,
+      tolerance
+    );
+    nextCentroids = recomputeCentroids(
+      dataset.units,
+      nextAssignment,
+      nextCentroids,
+      k
+    );
+    const metrics = computeMetrics(
+      dataset,
+      nextAssignment,
+      nextCentroids,
+      k,
+      options.election
+    );
+
+    return { assignment: nextAssignment, centroids: nextCentroids, metrics };
   }
 
-  if (remaining > 0) {
-    for (let i = 0; i < dataset.units.length; i++) {
-      if (assignment[i] >= 0) continue;
-      const order = nearestOrder(dataset.units[i].centroid, seeds);
-      const district = order.reduce(
-        (best, d) => (counts[d] < counts[best] ? d : best),
-        order[0]
-      );
-      assignment[i] = district;
-      counts[district] += dataset.units[i].population;
+  const adjacencyResult = finishWithFallback(true);
+  let selected = adjacencyResult;
+  if (
+    adjacencyResult.metrics.maxDeviationFraction > Math.max(0.25, tolerance * 2)
+  ) {
+    const capacityAwareResult = finishWithFallback(false);
+    const score = (result: typeof adjacencyResult) =>
+      result.metrics.maxDeviationFraction +
+      (k - result.metrics.contiguousDistricts) * 0.2;
+    if (score(capacityAwareResult) < score(adjacencyResult)) {
+      selected = capacityAwareResult;
     }
   }
-
-  let centroids = recomputeCentroids(dataset.units, assignment, seeds, k);
-  repairDisconnectedRegionComponents(dataset.units, assignment, k, tolerance);
-  centroids = recomputeCentroids(dataset.units, assignment, centroids, k);
-  rebalanceRegionGrowLowerBound(
-    dataset.units,
-    assignment,
-    centroids,
-    k,
-    tolerance
-  );
-  repairDisconnectedRegionComponents(dataset.units, assignment, k, tolerance);
-  centroids = recomputeCentroids(dataset.units, assignment, centroids, k);
 
   return {
     algorithm: 'Region growing',
-    assignment: assignmentToRecord(dataset.units, assignment),
-    centroids,
+    assignment: assignmentToRecord(dataset.units, selected.assignment),
+    centroids: selected.centroids,
     numDistricts: k,
-    metrics: computeMetrics(dataset, assignment, centroids, k, options.election),
+    metrics: selected.metrics,
   };
 }

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -542,7 +542,7 @@ function rebalanceRegionGrowLowerBound(
   // check synchronously from the visualization.
   const maxMoves = largeFixture
     ? Math.min(units.length * k, 120)
-    : Math.min(units.length * k, 2500);
+    : Math.min(units.length * k, units.length < 3000 ? 12000 : 2500);
   const shortlistSize = largeFixture ? 12 : 48;
 
   for (let move = 0; move < maxMoves; move++) {

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -418,6 +418,38 @@ function isDistrictConnectedAfterRemoving(
   );
 }
 
+// When removing a single "bridge" unit from its donor district would split the
+// donor into multiple components, the bridge plus every component except the
+// largest can be relocated as one group: the donor keeps its largest remaining
+// component (so it stays contiguous) and the cut-off leaves/components travel
+// with the bridge they hang off of. Returns null when removing the bridge does
+// not actually disconnect the donor (the single-unit move already suffices).
+function bridgeMoveGroup(
+  units: DistrictGeoUnit[],
+  assignment: number[],
+  bridgeIndex: number,
+  unitIndex: Map<string, number>
+): number[] | null {
+  const donor = assignment[bridgeIndex];
+  const components = districtComponents(
+    units,
+    assignment,
+    donor,
+    unitIndex,
+    bridgeIndex
+  );
+  if (components.length <= 1) return null;
+  components.sort(
+    (a, b) =>
+      b.reduce((s, i) => s + units[i].population, 0) -
+      a.reduce((s, i) => s + units[i].population, 0)
+  );
+  // Keep the largest component with the donor; move the bridge plus the rest.
+  const group = [bridgeIndex];
+  for (const component of components.slice(1)) group.push(...component);
+  return group;
+}
+
 function repairDisconnectedRegionComponents(
   units: DistrictGeoUnit[],
   assignment: number[],
@@ -554,25 +586,69 @@ function rebalanceRegionGrowLowerBound(
       }
     }
 
-    const bestMove = candidates
+    const shortlist = candidates
       .sort((a, b) => a.score - b.score)
-      .slice(0, shortlistSize)
-      .find((candidate) =>
-        isDistrictConnectedAfterRemoving(
-          units,
-          assignment,
-          candidate.fromDistrict,
-          candidate.unitIndex,
-          unitIndex
-        )
+      .slice(0, shortlistSize);
+
+    const bestMove = shortlist.find((candidate) =>
+      isDistrictConnectedAfterRemoving(
+        units,
+        assignment,
+        candidate.fromDistrict,
+        candidate.unitIndex,
+        unitIndex
+      )
+    );
+
+    if (bestMove) {
+      const population = units[bestMove.unitIndex].population;
+      assignment[bestMove.unitIndex] = bestMove.toDistrict;
+      counts[bestMove.fromDistrict] -= population;
+      counts[bestMove.toDistrict] += population;
+      continue;
+    }
+
+    // No single-unit move keeps the donor connected. The candidates that fail
+    // are bridge tracts: moving one alone would orphan a leaf/component. Move
+    // the bridge together with the cut-off component(s) so the donor keeps its
+    // largest remaining piece and the underfilled target still grows.
+    let bridgeMove: { group: number[]; toDistrict: number } | null = null;
+    for (const candidate of shortlist) {
+      const group = bridgeMoveGroup(
+        units,
+        assignment,
+        candidate.unitIndex,
+        unitIndex
       );
+      if (!group) continue;
+      const groupPopulation = group.reduce(
+        (s, idx) => s + units[idx].population,
+        0
+      );
+      if (counts[candidate.toDistrict] + groupPopulation > capacity) continue;
+      // Mirror the single-unit donor rule: the donor may dip below its floor
+      // as long as it stays above the target it is feeding (later passes can
+      // refill the donor from overfilled neighbors). This lets a starved
+      // district pull a bridge + leaf through an at-floor conduit district.
+      if (
+        counts[candidate.fromDistrict] - groupPopulation <=
+        counts[candidate.toDistrict] + groupPopulation
+      )
+        continue;
+      bridgeMove = { group, toDistrict: candidate.toDistrict };
+      break;
+    }
 
-    if (!bestMove) break;
+    if (!bridgeMove) break;
 
-    const population = units[bestMove.unitIndex].population;
-    assignment[bestMove.unitIndex] = bestMove.toDistrict;
-    counts[bestMove.fromDistrict] -= population;
-    counts[bestMove.toDistrict] += population;
+    const fromDistrict = assignment[bridgeMove.group[0]];
+    const groupPopulation = bridgeMove.group.reduce(
+      (s, idx) => s + units[idx].population,
+      0
+    );
+    for (const idx of bridgeMove.group) assignment[idx] = bridgeMove.toDistrict;
+    counts[fromDistrict] -= groupPopulation;
+    counts[bridgeMove.toDistrict] += groupPopulation;
   }
 
   for (let move = 0; move < maxMoves; move++) {

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -556,7 +556,7 @@ function rebalanceRegionGrowLowerBound(
   const maxMoves = largeFixture
     ? Math.min(units.length * k, 120)
     : units.length * k;
-  const shortlistSize = largeFixture ? 12 : 96;
+  const shortlistSize = largeFixture ? 12 : 48;
 
   for (let move = 0; move < maxMoves; move++) {
     const candidates: Array<{

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -1280,9 +1280,13 @@ export function districtRealByRegionGrow(
         adjacencyResult.metrics.contiguousDistricts &&
       capacityAwareResult.metrics.maxDeviationFraction <
         adjacencyResult.metrics.maxDeviationFraction * 0.5;
+    const catastrophicAdjacentOverflow =
+      adjacencyResult.metrics.maxDeviationFraction > 1 &&
+      capacityAwareResult.metrics.maxDeviationFraction < 0.2;
     if (
       score(capacityAwareResult) < score(adjacencyResult) ||
-      severeAdjacentOverflow
+      severeAdjacentOverflow ||
+      catastrophicAdjacentOverflow
     ) {
       selected = capacityAwareResult;
     }

--- a/apps/visualizations/lib/realDistricting.ts
+++ b/apps/visualizations/lib/realDistricting.ts
@@ -229,21 +229,25 @@ function weightedAssign(
   const counts = new Array(k).fill(0);
 
   for (const entry of ranked) {
-    const district = entry.distances.reduce((best, candidate, rank) => {
-      const projected = counts[candidate.idx] + entry.population;
-      const overCapacity = Math.max(0, projected - capacity) / Math.max(1, ideal);
-      const deficitBefore =
-        Math.max(0, lowerBound - counts[candidate.idx]) / Math.max(1, ideal);
-      const deficitAfter =
-        Math.max(0, lowerBound - projected) / Math.max(1, ideal);
-      const rankPenalty = rank / Math.max(1, k - 1);
-      const score =
-        overCapacity * 10000 +
-        deficitAfter * 6 -
-        deficitBefore * 8 +
-        rankPenalty;
-      return score < best.score ? { idx: candidate.idx, score } : best;
-    }, { idx: entry.distances[0].idx, score: Infinity }).idx;
+    const district = entry.distances.reduce(
+      (best, candidate, rank) => {
+        const projected = counts[candidate.idx] + entry.population;
+        const overCapacity =
+          Math.max(0, projected - capacity) / Math.max(1, ideal);
+        const deficitBefore =
+          Math.max(0, lowerBound - counts[candidate.idx]) / Math.max(1, ideal);
+        const deficitAfter =
+          Math.max(0, lowerBound - projected) / Math.max(1, ideal);
+        const rankPenalty = rank / Math.max(1, k - 1);
+        const score =
+          overCapacity * 10000 +
+          deficitAfter * 6 -
+          deficitBefore * 8 +
+          rankPenalty;
+        return score < best.score ? { idx: candidate.idx, score } : best;
+      },
+      { idx: entry.distances[0].idx, score: Infinity }
+    ).idx;
     assignment[entry.i] = district;
     counts[district] += entry.population;
   }
@@ -458,7 +462,6 @@ function repairDisconnectedRegionComponents(
 ) {
   const totalPopulation = units.reduce((s, unit) => s + unit.population, 0);
   const ideal = totalPopulation / k;
-  const lowerBound = ideal * (1 - tolerance);
   const capacity = ideal * (1 + tolerance);
   const unitIndex = new Map(units.map((unit, i) => [unit.geoid, i]));
   const counts = districtPopulations(units, assignment, k);
@@ -466,7 +469,12 @@ function repairDisconnectedRegionComponents(
   for (let pass = 0; pass < 4; pass++) {
     let changed = false;
     for (let district = 0; district < k; district++) {
-      const components = districtComponents(units, assignment, district, unitIndex);
+      const components = districtComponents(
+        units,
+        assignment,
+        district,
+        unitIndex
+      );
       if (components.length <= 1) continue;
 
       components.sort(
@@ -481,8 +489,6 @@ function repairDisconnectedRegionComponents(
           (s, i) => s + units[i].population,
           0
         );
-        if (counts[district] - componentPopulation < lowerBound) continue;
-
         const adjacentDistricts = new Set<number>();
         for (const idx of component) {
           for (const neighbor of units[idx].neighbors) {
@@ -491,16 +497,23 @@ function repairDisconnectedRegionComponents(
               continue;
             }
             const neighborDistrict = assignment[neighborIdx];
-            if (neighborDistrict !== district) adjacentDistricts.add(neighborDistrict);
+            if (neighborDistrict !== district)
+              adjacentDistricts.add(neighborDistrict);
           }
         }
 
         let target = -1;
+        let bestOverCapacity = Infinity;
         let bestPopulation = Infinity;
         for (const candidate of adjacentDistricts) {
           const projected = counts[candidate] + componentPopulation;
-          if (projected > capacity) continue;
-          if (counts[candidate] < bestPopulation) {
+          const overCapacity = Math.max(0, projected - capacity);
+          if (
+            overCapacity < bestOverCapacity ||
+            (overCapacity === bestOverCapacity &&
+              counts[candidate] < bestPopulation)
+          ) {
+            bestOverCapacity = overCapacity;
             bestPopulation = counts[candidate];
             target = candidate;
           }
@@ -562,7 +575,8 @@ function rebalanceRegionGrowLowerBound(
 
         const population = units[i].population;
         if (counts[targetDistrict] + population > capacity) continue;
-        if (counts[fromDistrict] - population <= counts[targetDistrict]) continue;
+        if (counts[fromDistrict] - population <= counts[targetDistrict])
+          continue;
 
         const touchesTarget = units[i].neighbors.some((neighbor) => {
           const neighborIdx = unitIndex.get(neighbor);
@@ -585,8 +599,12 @@ function rebalanceRegionGrowLowerBound(
 
         const targetDeficit =
           Math.max(0, lowerBound - targetAfter) / Math.max(1, ideal);
-        const distancePenalty = dist(units[i].centroid, centroids[targetDistrict]);
-        const score = targetDeficit * 1000 + afterBalance * 100 + distancePenalty;
+        const distancePenalty = dist(
+          units[i].centroid,
+          centroids[targetDistrict]
+        );
+        const score =
+          targetDeficit * 1000 + afterBalance * 100 + distancePenalty;
 
         candidates.push({
           unitIndex: i,
@@ -702,7 +720,7 @@ function rebalanceRegionGrowLowerBound(
           if (afterBalance >= beforeBalance) continue;
 
           const score =
-            Math.max(0, fromAfter - capacity) / Math.max(1, ideal) * 1000 +
+            (Math.max(0, fromAfter - capacity) / Math.max(1, ideal)) * 1000 +
             afterBalance * 100 +
             dist(units[i].centroid, centroids[toDistrict]);
           candidates.push({ unitIndex: i, fromDistrict, toDistrict, score });
@@ -710,25 +728,73 @@ function rebalanceRegionGrowLowerBound(
       }
     }
 
-    const bestMove = candidates
+    const shortlist = candidates
       .sort((a, b) => a.score - b.score)
-      .slice(0, shortlistSize)
-      .find((candidate) =>
-        isDistrictConnectedAfterRemoving(
-          units,
-          assignment,
-          candidate.fromDistrict,
-          candidate.unitIndex,
-          unitIndex
-        )
+      .slice(0, shortlistSize);
+
+    const bestMove = shortlist.find((candidate) =>
+      isDistrictConnectedAfterRemoving(
+        units,
+        assignment,
+        candidate.fromDistrict,
+        candidate.unitIndex,
+        unitIndex
+      )
+    );
+
+    if (bestMove) {
+      const population = units[bestMove.unitIndex].population;
+      assignment[bestMove.unitIndex] = bestMove.toDistrict;
+      counts[bestMove.fromDistrict] -= population;
+      counts[bestMove.toDistrict] += population;
+      continue;
+    }
+
+    let bridgeMove: { group: number[]; toDistrict: number } | null = null;
+    for (const candidate of shortlist) {
+      const group = bridgeMoveGroup(
+        units,
+        assignment,
+        candidate.unitIndex,
+        unitIndex
       );
+      if (!group) continue;
+      const groupPopulation = group.reduce(
+        (s, idx) => s + units[idx].population,
+        0
+      );
+      const fromAfter = counts[candidate.fromDistrict] - groupPopulation;
+      const toAfter = counts[candidate.toDistrict] + groupPopulation;
+      if (fromAfter < lowerBound || toAfter > capacity) continue;
 
-    if (!bestMove) break;
+      const beforeBalance =
+        Math.pow(
+          (counts[candidate.fromDistrict] - ideal) / Math.max(1, ideal),
+          2
+        ) +
+        Math.pow(
+          (counts[candidate.toDistrict] - ideal) / Math.max(1, ideal),
+          2
+        );
+      const afterBalance =
+        Math.pow((fromAfter - ideal) / Math.max(1, ideal), 2) +
+        Math.pow((toAfter - ideal) / Math.max(1, ideal), 2);
+      if (afterBalance >= beforeBalance) continue;
 
-    const population = units[bestMove.unitIndex].population;
-    assignment[bestMove.unitIndex] = bestMove.toDistrict;
-    counts[bestMove.fromDistrict] -= population;
-    counts[bestMove.toDistrict] += population;
+      bridgeMove = { group, toDistrict: candidate.toDistrict };
+      break;
+    }
+
+    if (!bridgeMove) break;
+
+    const fromDistrict = assignment[bridgeMove.group[0]];
+    const groupPopulation = bridgeMove.group.reduce(
+      (s, idx) => s + units[idx].population,
+      0
+    );
+    for (const idx of bridgeMove.group) assignment[idx] = bridgeMove.toDistrict;
+    counts[fromDistrict] -= groupPopulation;
+    counts[bridgeMove.toDistrict] += groupPopulation;
   }
 }
 
@@ -753,7 +819,8 @@ function computeMetrics(
       votingAgePopulations[district] += unit.votingAgePopulation;
       hasVotingAgePopulation = true;
     }
-    weightedDistance += unit.population * dist(unit.centroid, centroids[district]);
+    weightedDistance +=
+      unit.population * dist(unit.centroid, centroids[district]);
     totalPopulation += unit.population;
   }
 
@@ -796,9 +863,7 @@ function computeMetrics(
   const minPopulation = Math.min(...populations);
   const maxPopulation = Math.max(...populations);
   const maxDeviation = Math.max(
-    ...populations.map((population) =>
-      Math.abs(population - idealPopulation)
-    )
+    ...populations.map((population) => Math.abs(population - idealPopulation))
   );
 
   const partisanScores = election
@@ -915,7 +980,13 @@ export function districtRealByWeightedCentroid(
     assignment: assignmentToRecord(dataset.units, assignment),
     centroids,
     numDistricts: k,
-    metrics: computeMetrics(dataset, assignment, centroids, k, options.election),
+    metrics: computeMetrics(
+      dataset,
+      assignment,
+      centroids,
+      k,
+      options.election
+    ),
   };
 }
 
@@ -931,7 +1002,10 @@ export function districtRealByCountyIntegrity(
   } = options;
 
   const rand = mulberry32(seed * 40503 + 7);
-  const totalPopulation = dataset.units.reduce((s, unit) => s + unit.population, 0);
+  const totalPopulation = dataset.units.reduce(
+    (s, unit) => s + unit.population,
+    0
+  );
   const ideal = totalPopulation / k;
   const capacity = ideal * (1 + tolerance);
   const countyUnits = new Map<string, number[]>();
@@ -993,24 +1067,27 @@ export function districtRealByCountyIntegrity(
       for (const i of county.idxs) {
         const unit = dataset.units[i];
         const order = nearestOrder(unit.centroid, centroids);
-        const district = order.reduce((best, d, rank) => {
-          const projected = counts[d] + unit.population;
-          const overCapacity =
-            Math.max(0, projected - capacity) / Math.max(1, ideal);
-          const deficitBefore =
-            Math.max(0, ideal * (1 - tolerance) - counts[d]) /
-            Math.max(1, ideal);
-          const deficitAfter =
-            Math.max(0, ideal * (1 - tolerance) - projected) /
-            Math.max(1, ideal);
-          const rankPenalty = rank / Math.max(1, k - 1);
-          const score =
-            overCapacity * 10000 +
-            deficitAfter * 6 -
-            deficitBefore * 8 +
-            rankPenalty;
-          return score < best.score ? { idx: d, score } : best;
-        }, { idx: order[0], score: Infinity }).idx;
+        const district = order.reduce(
+          (best, d, rank) => {
+            const projected = counts[d] + unit.population;
+            const overCapacity =
+              Math.max(0, projected - capacity) / Math.max(1, ideal);
+            const deficitBefore =
+              Math.max(0, ideal * (1 - tolerance) - counts[d]) /
+              Math.max(1, ideal);
+            const deficitAfter =
+              Math.max(0, ideal * (1 - tolerance) - projected) /
+              Math.max(1, ideal);
+            const rankPenalty = rank / Math.max(1, k - 1);
+            const score =
+              overCapacity * 10000 +
+              deficitAfter * 6 -
+              deficitBefore * 8 +
+              rankPenalty;
+            return score < best.score ? { idx: d, score } : best;
+          },
+          { idx: order[0], score: Infinity }
+        ).idx;
         next[i] = district;
         counts[district] += unit.population;
       }
@@ -1036,7 +1113,13 @@ export function districtRealByCountyIntegrity(
     assignment: assignmentToRecord(dataset.units, assignment),
     centroids,
     numDistricts: k,
-    metrics: computeMetrics(dataset, assignment, centroids, k, options.election),
+    metrics: computeMetrics(
+      dataset,
+      assignment,
+      centroids,
+      k,
+      options.election
+    ),
   };
 }
 
@@ -1092,7 +1175,8 @@ export function districtRealByRegionGrow(
       for (const idx of frontiers[d]) {
         for (const neighbor of dataset.units[idx].neighbors) {
           const neighborIdx = unitIndex.get(neighbor);
-          if (neighborIdx === undefined || assignment[neighborIdx] >= 0) continue;
+          if (neighborIdx === undefined || assignment[neighborIdx] >= 0)
+            continue;
           candidates.add(neighborIdx);
         }
       }
@@ -1124,23 +1208,21 @@ export function districtRealByRegionGrow(
         const adjacentDistricts = new Set<number>();
         for (const neighbor of dataset.units[i].neighbors) {
           const neighborIdx = unitIndex.get(neighbor);
-          if (neighborIdx === undefined || assignment[neighborIdx] < 0) continue;
+          if (neighborIdx === undefined || assignment[neighborIdx] < 0)
+            continue;
           adjacentDistricts.add(assignment[neighborIdx]);
         }
         if (!adjacentDistricts.size) continue;
 
-        const district = Array.from(adjacentDistricts).reduce((best, d) => {
-          const bestOver = Math.max(
-            0,
-            counts[best] + dataset.units[i].population - capacity
-          );
-          const nextOver = Math.max(
-            0,
-            counts[d] + dataset.units[i].population - capacity
-          );
-          if (nextOver !== bestOver) return nextOver < bestOver ? d : best;
-          return counts[d] < counts[best] ? d : best;
-        }, Array.from(adjacentDistricts)[0]);
+        const population = dataset.units[i].population;
+        const capacityFits = Array.from(adjacentDistricts).filter(
+          (d) => counts[d] + population <= capacity
+        );
+        if (!capacityFits.length) continue;
+
+        const district = capacityFits.reduce((best, d) =>
+          counts[d] < counts[best] ? d : best
+        );
         assignment[i] = district;
         counts[district] += dataset.units[i].population;
         remaining--;
@@ -1181,6 +1263,12 @@ export function districtRealByRegionGrow(
     assignment: assignmentToRecord(dataset.units, assignment),
     centroids,
     numDistricts: k,
-    metrics: computeMetrics(dataset, assignment, centroids, k, options.election),
+    metrics: computeMetrics(
+      dataset,
+      assignment,
+      centroids,
+      k,
+      options.election
+    ),
   };
 }


### PR DESCRIPTION
Adds graph-aware repair passes to region growing so stranded components and underfilled districts can be rebalanced through adjacent boundary moves while preserving donor connectivity. Adds real Arizona and Maryland regression tests requiring contiguous districts and roughly 10% max population deviation. Keeps repair work bounded for large fixtures so California-scale runs return promptly while still exposing invalid metrics when a full repair is out of scope. Validated with `npm --workspace apps/visualizations test` and `npm --workspace apps/visualizations run build`; build still reports existing unrelated React hook dependency warnings.